### PR TITLE
Load shaders from shaders.json

### DIFF
--- a/client/.gitignore
+++ b/client/.gitignore
@@ -2,4 +2,5 @@ node_modules
 public/*.bundle.js
 public/*.bundle.js.*
 public/client-config.json
+public/shaders.json
 coverage

--- a/client/global.d.ts
+++ b/client/global.d.ts
@@ -1,3 +1,4 @@
 declare const __DEBUG__: boolean;
 declare const __TEST__: boolean;
 declare const __VERSION__: string;
+declare const __SHADER_HASH__: string;

--- a/client/pack-shaders.js
+++ b/client/pack-shaders.js
@@ -24,4 +24,4 @@ const shaders = fs
 
 console.log("Done. Writing...");
 fs.writeFileSync(OUTPUT_FILE, JSON.stringify(shaders));
-console.log(" --> " + OUTPUT_FILE);
+console.log(" --> " + OUTPUT_FILE + "\n");

--- a/client/pack-shaders.js
+++ b/client/pack-shaders.js
@@ -1,0 +1,27 @@
+/* eslint-disable */
+const fs = require("fs");
+const path = require("path");
+/* eslint-enable */
+
+const SHADER_DIR = path.join("src", "shader");
+const OUTPUT_FILE = path.join("public", "shaders.json");
+
+console.log("Loading shaders...");
+
+const shaders = fs
+    .readdirSync(SHADER_DIR)
+    .filter((filename) => filename.endsWith(".vert") || filename.endsWith(".frag"))
+    .reduce((shaders, filename) => {
+        console.log(" --> " + filename);
+
+        const rawContent = fs.readFileSync(SHADER_DIR + "/" + filename, "utf8");
+        shaders[filename] = rawContent.trim();
+
+        // TODO: consider minifying shaders (remove unnecessary whitespaces, rename variables, ...)
+
+        return shaders;
+    }, {});
+
+console.log("Done. Writing...");
+fs.writeFileSync(OUTPUT_FILE, JSON.stringify(shaders));
+console.log(" --> " + OUTPUT_FILE);

--- a/client/pack-shaders.js
+++ b/client/pack-shaders.js
@@ -1,6 +1,6 @@
 /* eslint-disable */
-const fs = require("fs");
-const path = require("path");
+const fs = require("node:fs");
+const path = require("node:path");
 /* eslint-enable */
 
 const SHADER_DIR = path.join("src", "shader");

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -31,12 +31,13 @@
             }
         },
         "node_modules/@ampproject/remapping": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.1.2.tgz",
-            "integrity": "sha512-hoyByceqwKirw7w3Z7gnIIZC3Wx3J484Y3L/cMpXFbr7d9ZQj2mODrirNzcJa+SM3UlpWXYvKV4RlRpFXlWgXg==",
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.0.tgz",
+            "integrity": "sha512-qRmjj8nj9qmLTQXXmaR1cck3UXSRMPrbsLJAasZpF+t3riI71BXed5ebIOYwQntykeZuhjsdweEc9BxH5Jc26w==",
             "dev": true,
             "dependencies": {
-                "@jridgewell/trace-mapping": "^0.3.0"
+                "@jridgewell/gen-mapping": "^0.1.0",
+                "@jridgewell/trace-mapping": "^0.3.9"
             },
             "engines": {
                 "node": ">=6.0.0"
@@ -617,9 +618,9 @@
             }
         },
         "node_modules/@eslint/eslintrc": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.2.1.tgz",
-            "integrity": "sha512-bxvbYnBPN1Gibwyp6NrpnFzA3YtRL3BBAyEAFVIpNTm2Rn4Vy87GA5M4aSn3InRrlsbX5N0GW7XIx+U4SAEKdQ==",
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.2.2.tgz",
+            "integrity": "sha512-lTVWHs7O2hjBFZunXTZYnYqtB9GakA1lnxIf+gKq2nY5gxkkNi/lQvveW6t8gFdOHTg6nG50Xs95PrLqVpcaLg==",
             "dev": true,
             "dependencies": {
                 "ajv": "^6.12.4",
@@ -952,10 +953,32 @@
                 "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
             }
         },
+        "node_modules/@jridgewell/gen-mapping": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.1.1.tgz",
+            "integrity": "sha512-sQXCasFk+U8lWYEe66WxRDOE9PjVz4vSM51fTu3Hw+ClTpUSQb718772vH3pyS5pShp6lvQM7SxgIDXXXmOX7w==",
+            "dev": true,
+            "dependencies": {
+                "@jridgewell/set-array": "^1.0.0",
+                "@jridgewell/sourcemap-codec": "^1.4.10"
+            },
+            "engines": {
+                "node": ">=6.0.0"
+            }
+        },
         "node_modules/@jridgewell/resolve-uri": {
-            "version": "3.0.5",
-            "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.0.5.tgz",
-            "integrity": "sha512-VPeQ7+wH0itvQxnG+lIzWgkysKIr3L9sslimFW55rHMdGu/qCQ5z5h9zq4gI8uBtqkpHhsF4Z/OwExufUCThew==",
+            "version": "3.0.6",
+            "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.0.6.tgz",
+            "integrity": "sha512-R7xHtBSNm+9SyvpJkdQl+qrM3Hm2fea3Ef197M3mUug+v+yR+Rhfbs7PBtcBUVnIWJ4JcAdjvij+c8hXS9p5aw==",
+            "dev": true,
+            "engines": {
+                "node": ">=6.0.0"
+            }
+        },
+        "node_modules/@jridgewell/set-array": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.0.tgz",
+            "integrity": "sha512-SfJxIxNVYLTsKwzB3MoOQ1yxf4w/E6MdkvTgrgAt1bfxjSrLUoHMKrDOykwN14q65waezZIdqDneUIPh4/sKxg==",
             "dev": true,
             "engines": {
                 "node": ">=6.0.0"
@@ -968,9 +991,9 @@
             "dev": true
         },
         "node_modules/@jridgewell/trace-mapping": {
-            "version": "0.3.4",
-            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.4.tgz",
-            "integrity": "sha512-vFv9ttIedivx0ux3QSjhgtCVjPZd5l46ZOMDSCwnH1yUO2e964gO8LZGyv2QkqcgR6TnBU1v+1IFqmeoG+0UJQ==",
+            "version": "0.3.9",
+            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+            "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
             "dev": true,
             "dependencies": {
                 "@jridgewell/resolve-uri": "^3.0.3",
@@ -1072,9 +1095,9 @@
             }
         },
         "node_modules/@types/babel__traverse": {
-            "version": "7.14.2",
-            "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.14.2.tgz",
-            "integrity": "sha512-K2waXdXBi2302XUdcHcR1jCeU0LL4TD9HRs/gk0N2Xvrht+G/BfJa4QObBQZfhMdxiCpV3COl5Nfq4uKTeTnJA==",
+            "version": "7.17.1",
+            "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.17.1.tgz",
+            "integrity": "sha512-kVzjari1s2YVi77D3w1yuvohV2idweYXMCDzqBiVNN63TcDWrIlTVOYpqVrvbbyOE/IyzBoTKF0fdnLPEORFxA==",
             "dev": true,
             "dependencies": {
                 "@babel/types": "^7.3.0"
@@ -1156,15 +1179,15 @@
             "dev": true
         },
         "node_modules/@types/node": {
-            "version": "17.0.23",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.23.tgz",
-            "integrity": "sha512-UxDxWn7dl97rKVeVS61vErvw086aCYhDLyvRQZ5Rk65rZKepaFdm53GeqXaKBuOhED4e9uWq34IC3TdSdJJ2Gw==",
+            "version": "17.0.29",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.29.tgz",
+            "integrity": "sha512-tx5jMmMFwx7wBwq/V7OohKDVb/JwJU5qCVkeLMh1//xycAJ/ESuw9aJ9SEtlCZDYi2pBfe4JkisSoAtbOsBNAA==",
             "dev": true
         },
         "node_modules/@types/prettier": {
-            "version": "2.4.4",
-            "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.4.4.tgz",
-            "integrity": "sha512-ReVR2rLTV1kvtlWFyuot+d1pkpG2Fw/XKE3PDAdj57rbM97ttSp9JZ2UsP+2EHTylra9cUf6JA7tGwW1INzUrA==",
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.6.0.tgz",
+            "integrity": "sha512-G/AdOadiZhnJp0jXCaBQU449W2h716OW/EoXeYkCytxKL06X1WCXB4DZpp8TpZ8eyIJVS1cw4lrlkkSYU21cDw==",
             "dev": true
         },
         "node_modules/@types/stack-utils": {
@@ -1189,14 +1212,14 @@
             "dev": true
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
-            "version": "5.18.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.18.0.tgz",
-            "integrity": "sha512-tzrmdGMJI/uii9/V6lurMo4/o+dMTKDH82LkNjhJ3adCW22YQydoRs5MwTiqxGF9CSYxPxQ7EYb4jLNlIs+E+A==",
+            "version": "5.21.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.21.0.tgz",
+            "integrity": "sha512-fTU85q8v5ZLpoZEyn/u1S2qrFOhi33Edo2CZ0+q1gDaWWm0JuPh3bgOyU8lM0edIEYgKLDkPFiZX2MOupgjlyg==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/scope-manager": "5.18.0",
-                "@typescript-eslint/type-utils": "5.18.0",
-                "@typescript-eslint/utils": "5.18.0",
+                "@typescript-eslint/scope-manager": "5.21.0",
+                "@typescript-eslint/type-utils": "5.21.0",
+                "@typescript-eslint/utils": "5.21.0",
                 "debug": "^4.3.2",
                 "functional-red-black-tree": "^1.0.1",
                 "ignore": "^5.1.8",
@@ -1222,14 +1245,14 @@
             }
         },
         "node_modules/@typescript-eslint/parser": {
-            "version": "5.18.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.18.0.tgz",
-            "integrity": "sha512-+08nYfurBzSSPndngnHvFw/fniWYJ5ymOrn/63oMIbgomVQOvIDhBoJmYZ9lwQOCnQV9xHGvf88ze3jFGUYooQ==",
+            "version": "5.21.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.21.0.tgz",
+            "integrity": "sha512-8RUwTO77hstXUr3pZoWZbRQUxXcSXafZ8/5gpnQCfXvgmP9gpNlRGlWzvfbEQ14TLjmtU8eGnONkff8U2ui2Eg==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/scope-manager": "5.18.0",
-                "@typescript-eslint/types": "5.18.0",
-                "@typescript-eslint/typescript-estree": "5.18.0",
+                "@typescript-eslint/scope-manager": "5.21.0",
+                "@typescript-eslint/types": "5.21.0",
+                "@typescript-eslint/typescript-estree": "5.21.0",
                 "debug": "^4.3.2"
             },
             "engines": {
@@ -1249,13 +1272,13 @@
             }
         },
         "node_modules/@typescript-eslint/scope-manager": {
-            "version": "5.18.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.18.0.tgz",
-            "integrity": "sha512-C0CZML6NyRDj+ZbMqh9FnPscg2PrzSaVQg3IpTmpe0NURMVBXlghGZgMYqBw07YW73i0MCqSDqv2SbywnCS8jQ==",
+            "version": "5.21.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.21.0.tgz",
+            "integrity": "sha512-XTX0g0IhvzcH/e3393SvjRCfYQxgxtYzL3UREteUneo72EFlt7UNoiYnikUtmGVobTbhUDByhJ4xRBNe+34kOQ==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/types": "5.18.0",
-                "@typescript-eslint/visitor-keys": "5.18.0"
+                "@typescript-eslint/types": "5.21.0",
+                "@typescript-eslint/visitor-keys": "5.21.0"
             },
             "engines": {
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -1266,12 +1289,12 @@
             }
         },
         "node_modules/@typescript-eslint/type-utils": {
-            "version": "5.18.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.18.0.tgz",
-            "integrity": "sha512-vcn9/6J5D6jtHxpEJrgK8FhaM8r6J1/ZiNu70ZUJN554Y3D9t3iovi6u7JF8l/e7FcBIxeuTEidZDR70UuCIfA==",
+            "version": "5.21.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.21.0.tgz",
+            "integrity": "sha512-MxmLZj0tkGlkcZCSE17ORaHl8Th3JQwBzyXL/uvC6sNmu128LsgjTX0NIzy+wdH2J7Pd02GN8FaoudJntFvSOw==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/utils": "5.18.0",
+                "@typescript-eslint/utils": "5.21.0",
                 "debug": "^4.3.2",
                 "tsutils": "^3.21.0"
             },
@@ -1292,9 +1315,9 @@
             }
         },
         "node_modules/@typescript-eslint/types": {
-            "version": "5.18.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.18.0.tgz",
-            "integrity": "sha512-bhV1+XjM+9bHMTmXi46p1Led5NP6iqQcsOxgx7fvk6gGiV48c6IynY0apQb7693twJDsXiVzNXTflhplmaiJaw==",
+            "version": "5.21.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.21.0.tgz",
+            "integrity": "sha512-XnOOo5Wc2cBlq8Lh5WNvAgHzpjnEzxn4CJBwGkcau7b/tZ556qrWXQz4DJyChYg8JZAD06kczrdgFPpEQZfDsA==",
             "dev": true,
             "engines": {
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -1305,13 +1328,13 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree": {
-            "version": "5.18.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.18.0.tgz",
-            "integrity": "sha512-wa+2VAhOPpZs1bVij9e5gyVu60ReMi/KuOx4LKjGx2Y3XTNUDJgQ+5f77D49pHtqef/klglf+mibuHs9TrPxdQ==",
+            "version": "5.21.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.21.0.tgz",
+            "integrity": "sha512-Y8Y2T2FNvm08qlcoSMoNchh9y2Uj3QmjtwNMdRQkcFG7Muz//wfJBGBxh8R7HAGQFpgYpdHqUpEoPQk+q9Kjfg==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/types": "5.18.0",
-                "@typescript-eslint/visitor-keys": "5.18.0",
+                "@typescript-eslint/types": "5.21.0",
+                "@typescript-eslint/visitor-keys": "5.21.0",
                 "debug": "^4.3.2",
                 "globby": "^11.0.4",
                 "is-glob": "^4.0.3",
@@ -1332,15 +1355,15 @@
             }
         },
         "node_modules/@typescript-eslint/utils": {
-            "version": "5.18.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.18.0.tgz",
-            "integrity": "sha512-+hFGWUMMri7OFY26TsOlGa+zgjEy1ssEipxpLjtl4wSll8zy85x0GrUSju/FHdKfVorZPYJLkF3I4XPtnCTewA==",
+            "version": "5.21.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.21.0.tgz",
+            "integrity": "sha512-q/emogbND9wry7zxy7VYri+7ydawo2HDZhRZ5k6yggIvXa7PvBbAAZ4PFH/oZLem72ezC4Pr63rJvDK/sTlL8Q==",
             "dev": true,
             "dependencies": {
                 "@types/json-schema": "^7.0.9",
-                "@typescript-eslint/scope-manager": "5.18.0",
-                "@typescript-eslint/types": "5.18.0",
-                "@typescript-eslint/typescript-estree": "5.18.0",
+                "@typescript-eslint/scope-manager": "5.21.0",
+                "@typescript-eslint/types": "5.21.0",
+                "@typescript-eslint/typescript-estree": "5.21.0",
                 "eslint-scope": "^5.1.1",
                 "eslint-utils": "^3.0.0"
             },
@@ -1356,12 +1379,12 @@
             }
         },
         "node_modules/@typescript-eslint/visitor-keys": {
-            "version": "5.18.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.18.0.tgz",
-            "integrity": "sha512-Hf+t+dJsjAKpKSkg3EHvbtEpFFb/1CiOHnvI8bjHgOD4/wAw3gKrA0i94LrbekypiZVanJu3McWJg7rWDMzRTg==",
+            "version": "5.21.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.21.0.tgz",
+            "integrity": "sha512-SX8jNN+iHqAF0riZQMkm7e8+POXa/fXw5cxL+gjpyP+FI+JVNhii53EmQgDAfDcBpFekYSlO0fGytMQwRiMQCA==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/types": "5.18.0",
+                "@typescript-eslint/types": "5.21.0",
                 "eslint-visitor-keys": "^3.0.0"
             },
             "engines": {
@@ -1567,15 +1590,15 @@
             "dev": true
         },
         "node_modules/abab": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.5.tgz",
-            "integrity": "sha512-9IK9EadsbHo6jLWIpxpR6pL0sazTXV6+SQv25ZB+F7Bj9mJNaOc4nCRabwd5M/JwmUa8idz6Eci6eKfJryPs6Q==",
+            "version": "2.0.6",
+            "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.6.tgz",
+            "integrity": "sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==",
             "dev": true
         },
         "node_modules/acorn": {
-            "version": "8.7.0",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
-            "integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==",
+            "version": "8.7.1",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.1.tgz",
+            "integrity": "sha512-Xx54uLJQZ19lKygFXOWsscKUbsBZW0CPykPhVQdhIeIwrbPmJzqeASDInc8nKBnp/JT6igTs82qPXz069H8I/A==",
             "dev": true,
             "bin": {
                 "acorn": "bin/acorn"
@@ -1891,9 +1914,9 @@
             "dev": true
         },
         "node_modules/browserslist": {
-            "version": "4.20.2",
-            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.20.2.tgz",
-            "integrity": "sha512-CQOBCqp/9pDvDbx3xfMi+86pr4KXIf2FDkTTdeuYw8OxS9t898LA1Khq57gtufFILXpfgsSx5woNgsBgvGjpsA==",
+            "version": "4.20.3",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.20.3.tgz",
+            "integrity": "sha512-NBhymBQl1zM0Y5dQT/O+xiLP9/rzOIQdKM/eMJBAq7yBgaB6krIYLGejrwVYnSHZdqjscB1SPuAjHwxjvN6Wdg==",
             "dev": true,
             "funding": [
                 {
@@ -1906,10 +1929,10 @@
                 }
             ],
             "dependencies": {
-                "caniuse-lite": "^1.0.30001317",
-                "electron-to-chromium": "^1.4.84",
+                "caniuse-lite": "^1.0.30001332",
+                "electron-to-chromium": "^1.4.118",
                 "escalade": "^3.1.1",
-                "node-releases": "^2.0.2",
+                "node-releases": "^2.0.3",
                 "picocolors": "^1.0.0"
             },
             "bin": {
@@ -1965,9 +1988,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001325",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001325.tgz",
-            "integrity": "sha512-sB1bZHjseSjDtijV1Hb7PB2Zd58Kyx+n/9EotvZ4Qcz2K3d0lWB8dB4nb8wN/TsOGFq3UuAm0zQZNQ4SoR7TrQ==",
+            "version": "1.0.30001332",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001332.tgz",
+            "integrity": "sha512-10T30NYOEQtN6C11YGg411yebhvpnC6Z102+B95eAsN0oB6KUs01ivE8u+G6FMIRtIrVlYXhL+LUwQ3/hXwDWw==",
             "dev": true,
             "funding": [
                 {
@@ -2356,9 +2379,9 @@
             }
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.4.104",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.104.tgz",
-            "integrity": "sha512-2kjoAyiG7uMyGRM9mx25s3HAzmQG2ayuYXxsFmYugHSDcwxREgLtscZvbL1JcW9S/OemeQ3f/SG6JhDwpnCclQ==",
+            "version": "1.4.123",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.123.tgz",
+            "integrity": "sha512-0pHGE53WkYoFbsgwYcVKEpWa6jbzlvkohIEA2CUoZ9b5KC+w/zlMiQHvW/4IBcOh7YoEFqRNavgTk02TBoUTUw==",
             "dev": true
         },
         "node_modules/emittery": {
@@ -2545,12 +2568,12 @@
             }
         },
         "node_modules/eslint": {
-            "version": "8.12.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.12.0.tgz",
-            "integrity": "sha512-it1oBL9alZg1S8UycLm5YDMAkIhtH6FtAzuZs6YvoGVldWjbS08BkAdb/ymP9LlAyq8koANu32U7Ib/w+UNh8Q==",
+            "version": "8.14.0",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.14.0.tgz",
+            "integrity": "sha512-3/CE4aJX7LNEiE3i6FeodHmI/38GZtWCsAtsymScmzYapx8q1nVVb+eLcLSzATmCPXw5pT4TqVs1E0OmxAd9tw==",
             "dev": true,
             "dependencies": {
-                "@eslint/eslintrc": "^1.2.1",
+                "@eslint/eslintrc": "^1.2.2",
                 "@humanwhocodes/config-array": "^0.9.2",
                 "ajv": "^6.10.0",
                 "chalk": "^4.0.0",
@@ -3154,9 +3177,9 @@
             }
         },
         "node_modules/https-proxy-agent": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
-            "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+            "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
             "dev": true,
             "dependencies": {
                 "agent-base": "6",
@@ -3297,9 +3320,9 @@
             "dev": true
         },
         "node_modules/is-core-module": {
-            "version": "2.8.1",
-            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.1.tgz",
-            "integrity": "sha512-SdNCUs284hr40hFTFP6l0IfZ/RSrMXF3qgoRHd3/79unUTvrFO/JoXwkGm+5J/Oe3E/b5GsnG330uUNgRpu1PA==",
+            "version": "2.9.0",
+            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.9.0.tgz",
+            "integrity": "sha512-+5FPy5PnwmO3lvfMb0AsoPaBG+5KHUI0wYFXOtYPnVVVspTFUuMZNfNaNVRt3FZadstu2c8x23vykRW/NBoU6A==",
             "dev": true,
             "dependencies": {
                 "has": "^1.0.3"
@@ -3429,9 +3452,9 @@
             }
         },
         "node_modules/istanbul-lib-instrument": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-5.1.0.tgz",
-            "integrity": "sha512-czwUz525rkOFDJxfKK6mYfIs9zBKILyrZQxjz3ABhjQXhbhFsSbo1HW/BFcsDnfJYJWA6thRR5/TUY2qs5W99Q==",
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-5.2.0.tgz",
+            "integrity": "sha512-6Lthe1hqXHBNsqvgDzGO6l03XNeu3CrG4RqQ1KM9+l5+jNGpEJfIELx1NS3SEHmJQA8np/u+E4EPRKRiu6m19A==",
             "dev": true,
             "dependencies": {
                 "@babel/core": "^7.12.3",
@@ -4345,9 +4368,9 @@
             "dev": true
         },
         "node_modules/loader-runner": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.2.0.tgz",
-            "integrity": "sha512-92+huvxMvYlMzMt0iIOukcwYBFpkYJdpl2xsZ7LrlayO7E8SOv+JJUEK17B/dJIHAOLMfh2dZZ/Y18WgmGtYNw==",
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.0.tgz",
+            "integrity": "sha512-3R/1M+yS3j5ou80Me59j7F9IMs4PXs3VqRrm0TU3AbKPxlmpoY1TNscJV/oGJXo8qCatFGTfDbY6W6ipGOYXfg==",
             "dev": true,
             "engines": {
                 "node": ">=6.11.5"
@@ -4397,13 +4420,22 @@
             "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
             "dev": true
         },
+        "node_modules/lodash.sortby": {
+            "version": "4.7.0",
+            "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+            "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
+            "dev": true
+        },
         "node_modules/lru-cache": {
-            "version": "7.7.3",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.7.3.tgz",
-            "integrity": "sha512-WY9wjJNQt9+PZilnLbuFKM+SwDull9+6IAguOrarOMoOHTcJ9GnXSO11+Gw6c7xtDkBkthR57OZMtZKYr+1CEw==",
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+            "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
             "dev": true,
+            "dependencies": {
+                "yallist": "^4.0.0"
+            },
             "engines": {
-                "node": ">=12"
+                "node": ">=10"
             }
         },
         "node_modules/make-dir": {
@@ -4548,9 +4580,9 @@
             "dev": true
         },
         "node_modules/nanoid": {
-            "version": "3.3.2",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.2.tgz",
-            "integrity": "sha512-CuHBogktKwpm5g2sRgv83jEy2ijFzBwMoYA60orPDR7ynsLijJDqgsi4RDGj3OJpy3Ieb+LYwiRmIOGyytgITA==",
+            "version": "3.3.3",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.3.tgz",
+            "integrity": "sha512-p1sjXuopFs0xg+fPASzQ28agW1oHD7xDsd9Xkf3T15H3c/cifrFHVwrh74PdoklAPi+i7MdRsE47vm2r6JoB+w==",
             "dev": true,
             "bin": {
                 "nanoid": "bin/nanoid.cjs"
@@ -4606,9 +4638,9 @@
             "dev": true
         },
         "node_modules/node-releases": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.2.tgz",
-            "integrity": "sha512-XxYDdcQ6eKqp/YjI+tb2C5WM2LgjnZrfYg4vgQt49EK268b6gYCHsBLrK2qvJo4FmCtqmKezb0WZFK4fkrZNsg==",
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.3.tgz",
+            "integrity": "sha512-maHFz6OLqYxz+VQyCAtA3PTX4UP/53pa05fyDNc9CwjvJ0yEh6+xBwKsgCxMNhS8taUKBFYxfuiaD9U/55iFaw==",
             "dev": true
         },
         "node_modules/normalize-path": {
@@ -5295,18 +5327,18 @@
             }
         },
         "node_modules/semver": {
-            "version": "7.3.6",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.6.tgz",
-            "integrity": "sha512-HZWqcgwLsjaX1HBD31msI/rXktuIhS+lWvdE4kN9z+8IVT4Itc7vqU2WvYsyD6/sjYCt4dEKH/m1M3dwI9CC5w==",
+            "version": "7.3.7",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+            "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
             "dev": true,
             "dependencies": {
-                "lru-cache": "^7.4.0"
+                "lru-cache": "^6.0.0"
             },
             "bin": {
                 "semver": "bin/semver.js"
             },
             "engines": {
-                "node": "^10.0.0 || ^12.0.0 || ^14.0.0 || >=16.0.0"
+                "node": ">=10"
             }
         },
         "node_modules/serialize-javascript": {
@@ -5594,14 +5626,14 @@
             }
         },
         "node_modules/terser": {
-            "version": "5.12.1",
-            "resolved": "https://registry.npmjs.org/terser/-/terser-5.12.1.tgz",
-            "integrity": "sha512-NXbs+7nisos5E+yXwAD+y7zrcTkMqb0dEJxIGtSKPdCBzopf7ni4odPul2aechpV7EXNvOudYOX2bb5tln1jbQ==",
+            "version": "5.13.0",
+            "resolved": "https://registry.npmjs.org/terser/-/terser-5.13.0.tgz",
+            "integrity": "sha512-sgQ99P+fRBM1jAYzN9RTnD/xEWx/7LZgYTCRgmYriSq1wxxqiQPJgXkkLBBuwySDWJ2PP0PnVQyuf4xLUuH4Ng==",
             "dev": true,
             "dependencies": {
                 "acorn": "^8.5.0",
                 "commander": "^2.20.0",
-                "source-map": "~0.7.2",
+                "source-map": "~0.8.0-beta.0",
                 "source-map-support": "~0.5.20"
             },
             "bin": {
@@ -5646,12 +5678,41 @@
             }
         },
         "node_modules/terser/node_modules/source-map": {
-            "version": "0.7.3",
-            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
-            "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
+            "version": "0.8.0-beta.0",
+            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.8.0-beta.0.tgz",
+            "integrity": "sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA==",
             "dev": true,
+            "dependencies": {
+                "whatwg-url": "^7.0.0"
+            },
             "engines": {
                 "node": ">= 8"
+            }
+        },
+        "node_modules/terser/node_modules/tr46": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
+            "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
+            "dev": true,
+            "dependencies": {
+                "punycode": "^2.1.0"
+            }
+        },
+        "node_modules/terser/node_modules/webidl-conversions": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
+            "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
+            "dev": true
+        },
+        "node_modules/terser/node_modules/whatwg-url": {
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
+            "integrity": "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==",
+            "dev": true,
+            "dependencies": {
+                "lodash.sortby": "^4.7.0",
+                "tr46": "^1.0.1",
+                "webidl-conversions": "^4.0.2"
             }
         },
         "node_modules/test-exclude": {
@@ -5777,9 +5838,9 @@
             }
         },
         "node_modules/ts-loader": {
-            "version": "8.3.0",
-            "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-8.3.0.tgz",
-            "integrity": "sha512-MgGly4I6cStsJy27ViE32UoqxPTN9Xly4anxxVyaIWR+9BGxboV4EyJBGfR3RePV7Ksjj3rHmPZJeIt+7o4Vag==",
+            "version": "8.4.0",
+            "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-8.4.0.tgz",
+            "integrity": "sha512-6nFY3IZ2//mrPc+ImY3hNWx1vCHyEhl6V+wLmL4CZcm6g1CqX7UKrkc6y0i4FwcfOhxyMPCfaEvh20f4r9GNpw==",
             "dev": true,
             "dependencies": {
                 "chalk": "^4.1.0",
@@ -5797,9 +5858,9 @@
             }
         },
         "node_modules/tslib": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-            "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+            "version": "2.4.0",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+            "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
             "dev": true
         },
         "node_modules/tsutils": {
@@ -5984,9 +6045,9 @@
             }
         },
         "node_modules/webpack": {
-            "version": "5.71.0",
-            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.71.0.tgz",
-            "integrity": "sha512-g4dFT7CFG8LY0iU5G8nBL6VlkT21Z7dcYDpJAEJV5Q1WLb9UwnFbrem1k7K52ILqEmomN7pnzWFxxE6SlDY56A==",
+            "version": "5.72.0",
+            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.72.0.tgz",
+            "integrity": "sha512-qmSmbspI0Qo5ld49htys8GY9XhS9CGqFoHTsOVAnjBdg0Zn79y135R+k4IR4rKK6+eKaabMhJwiVB7xw0SJu5w==",
             "dev": true,
             "dependencies": {
                 "@types/eslint-scope": "^3.7.3",
@@ -6105,9 +6166,9 @@
             }
         },
         "node_modules/webpack/node_modules/enhanced-resolve": {
-            "version": "5.9.2",
-            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.9.2.tgz",
-            "integrity": "sha512-GIm3fQfwLJ8YZx2smuHpBKkXC1yOk+OBEmKckVyL0i/ea8mqDEykK3ld5dgH1QYPNyT/lIllxV2LULnxCHaHkA==",
+            "version": "5.9.3",
+            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.9.3.tgz",
+            "integrity": "sha512-Bq9VSor+kjvW3f9/MiiR4eE3XYgOl7/rS8lnSxbRbF3kS0B2r+Y9w5krBWxZgDxASVZbdYrn5wT4j/Wb0J9qow==",
             "dev": true,
             "dependencies": {
                 "graceful-fs": "^4.2.4",
@@ -6262,6 +6323,12 @@
                 "node": ">=10"
             }
         },
+        "node_modules/yallist": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+            "dev": true
+        },
         "node_modules/yargs": {
             "version": "16.2.0",
             "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
@@ -6292,12 +6359,13 @@
     },
     "dependencies": {
         "@ampproject/remapping": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.1.2.tgz",
-            "integrity": "sha512-hoyByceqwKirw7w3Z7gnIIZC3Wx3J484Y3L/cMpXFbr7d9ZQj2mODrirNzcJa+SM3UlpWXYvKV4RlRpFXlWgXg==",
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.0.tgz",
+            "integrity": "sha512-qRmjj8nj9qmLTQXXmaR1cck3UXSRMPrbsLJAasZpF+t3riI71BXed5ebIOYwQntykeZuhjsdweEc9BxH5Jc26w==",
             "dev": true,
             "requires": {
-                "@jridgewell/trace-mapping": "^0.3.0"
+                "@jridgewell/gen-mapping": "^0.1.0",
+                "@jridgewell/trace-mapping": "^0.3.9"
             }
         },
         "@babel/code-frame": {
@@ -6737,9 +6805,9 @@
             "dev": true
         },
         "@eslint/eslintrc": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.2.1.tgz",
-            "integrity": "sha512-bxvbYnBPN1Gibwyp6NrpnFzA3YtRL3BBAyEAFVIpNTm2Rn4Vy87GA5M4aSn3InRrlsbX5N0GW7XIx+U4SAEKdQ==",
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.2.2.tgz",
+            "integrity": "sha512-lTVWHs7O2hjBFZunXTZYnYqtB9GakA1lnxIf+gKq2nY5gxkkNi/lQvveW6t8gFdOHTg6nG50Xs95PrLqVpcaLg==",
             "dev": true,
             "requires": {
                 "ajv": "^6.12.4",
@@ -7007,10 +7075,26 @@
                 "chalk": "^4.0.0"
             }
         },
+        "@jridgewell/gen-mapping": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.1.1.tgz",
+            "integrity": "sha512-sQXCasFk+U8lWYEe66WxRDOE9PjVz4vSM51fTu3Hw+ClTpUSQb718772vH3pyS5pShp6lvQM7SxgIDXXXmOX7w==",
+            "dev": true,
+            "requires": {
+                "@jridgewell/set-array": "^1.0.0",
+                "@jridgewell/sourcemap-codec": "^1.4.10"
+            }
+        },
         "@jridgewell/resolve-uri": {
-            "version": "3.0.5",
-            "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.0.5.tgz",
-            "integrity": "sha512-VPeQ7+wH0itvQxnG+lIzWgkysKIr3L9sslimFW55rHMdGu/qCQ5z5h9zq4gI8uBtqkpHhsF4Z/OwExufUCThew==",
+            "version": "3.0.6",
+            "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.0.6.tgz",
+            "integrity": "sha512-R7xHtBSNm+9SyvpJkdQl+qrM3Hm2fea3Ef197M3mUug+v+yR+Rhfbs7PBtcBUVnIWJ4JcAdjvij+c8hXS9p5aw==",
+            "dev": true
+        },
+        "@jridgewell/set-array": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.0.tgz",
+            "integrity": "sha512-SfJxIxNVYLTsKwzB3MoOQ1yxf4w/E6MdkvTgrgAt1bfxjSrLUoHMKrDOykwN14q65waezZIdqDneUIPh4/sKxg==",
             "dev": true
         },
         "@jridgewell/sourcemap-codec": {
@@ -7020,9 +7104,9 @@
             "dev": true
         },
         "@jridgewell/trace-mapping": {
-            "version": "0.3.4",
-            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.4.tgz",
-            "integrity": "sha512-vFv9ttIedivx0ux3QSjhgtCVjPZd5l46ZOMDSCwnH1yUO2e964gO8LZGyv2QkqcgR6TnBU1v+1IFqmeoG+0UJQ==",
+            "version": "0.3.9",
+            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+            "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
             "dev": true,
             "requires": {
                 "@jridgewell/resolve-uri": "^3.0.3",
@@ -7112,9 +7196,9 @@
             }
         },
         "@types/babel__traverse": {
-            "version": "7.14.2",
-            "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.14.2.tgz",
-            "integrity": "sha512-K2waXdXBi2302XUdcHcR1jCeU0LL4TD9HRs/gk0N2Xvrht+G/BfJa4QObBQZfhMdxiCpV3COl5Nfq4uKTeTnJA==",
+            "version": "7.17.1",
+            "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.17.1.tgz",
+            "integrity": "sha512-kVzjari1s2YVi77D3w1yuvohV2idweYXMCDzqBiVNN63TcDWrIlTVOYpqVrvbbyOE/IyzBoTKF0fdnLPEORFxA==",
             "dev": true,
             "requires": {
                 "@babel/types": "^7.3.0"
@@ -7196,15 +7280,15 @@
             "dev": true
         },
         "@types/node": {
-            "version": "17.0.23",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.23.tgz",
-            "integrity": "sha512-UxDxWn7dl97rKVeVS61vErvw086aCYhDLyvRQZ5Rk65rZKepaFdm53GeqXaKBuOhED4e9uWq34IC3TdSdJJ2Gw==",
+            "version": "17.0.29",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.29.tgz",
+            "integrity": "sha512-tx5jMmMFwx7wBwq/V7OohKDVb/JwJU5qCVkeLMh1//xycAJ/ESuw9aJ9SEtlCZDYi2pBfe4JkisSoAtbOsBNAA==",
             "dev": true
         },
         "@types/prettier": {
-            "version": "2.4.4",
-            "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.4.4.tgz",
-            "integrity": "sha512-ReVR2rLTV1kvtlWFyuot+d1pkpG2Fw/XKE3PDAdj57rbM97ttSp9JZ2UsP+2EHTylra9cUf6JA7tGwW1INzUrA==",
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.6.0.tgz",
+            "integrity": "sha512-G/AdOadiZhnJp0jXCaBQU449W2h716OW/EoXeYkCytxKL06X1WCXB4DZpp8TpZ8eyIJVS1cw4lrlkkSYU21cDw==",
             "dev": true
         },
         "@types/stack-utils": {
@@ -7229,14 +7313,14 @@
             "dev": true
         },
         "@typescript-eslint/eslint-plugin": {
-            "version": "5.18.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.18.0.tgz",
-            "integrity": "sha512-tzrmdGMJI/uii9/V6lurMo4/o+dMTKDH82LkNjhJ3adCW22YQydoRs5MwTiqxGF9CSYxPxQ7EYb4jLNlIs+E+A==",
+            "version": "5.21.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.21.0.tgz",
+            "integrity": "sha512-fTU85q8v5ZLpoZEyn/u1S2qrFOhi33Edo2CZ0+q1gDaWWm0JuPh3bgOyU8lM0edIEYgKLDkPFiZX2MOupgjlyg==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/scope-manager": "5.18.0",
-                "@typescript-eslint/type-utils": "5.18.0",
-                "@typescript-eslint/utils": "5.18.0",
+                "@typescript-eslint/scope-manager": "5.21.0",
+                "@typescript-eslint/type-utils": "5.21.0",
+                "@typescript-eslint/utils": "5.21.0",
                 "debug": "^4.3.2",
                 "functional-red-black-tree": "^1.0.1",
                 "ignore": "^5.1.8",
@@ -7246,52 +7330,52 @@
             }
         },
         "@typescript-eslint/parser": {
-            "version": "5.18.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.18.0.tgz",
-            "integrity": "sha512-+08nYfurBzSSPndngnHvFw/fniWYJ5ymOrn/63oMIbgomVQOvIDhBoJmYZ9lwQOCnQV9xHGvf88ze3jFGUYooQ==",
+            "version": "5.21.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.21.0.tgz",
+            "integrity": "sha512-8RUwTO77hstXUr3pZoWZbRQUxXcSXafZ8/5gpnQCfXvgmP9gpNlRGlWzvfbEQ14TLjmtU8eGnONkff8U2ui2Eg==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/scope-manager": "5.18.0",
-                "@typescript-eslint/types": "5.18.0",
-                "@typescript-eslint/typescript-estree": "5.18.0",
+                "@typescript-eslint/scope-manager": "5.21.0",
+                "@typescript-eslint/types": "5.21.0",
+                "@typescript-eslint/typescript-estree": "5.21.0",
                 "debug": "^4.3.2"
             }
         },
         "@typescript-eslint/scope-manager": {
-            "version": "5.18.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.18.0.tgz",
-            "integrity": "sha512-C0CZML6NyRDj+ZbMqh9FnPscg2PrzSaVQg3IpTmpe0NURMVBXlghGZgMYqBw07YW73i0MCqSDqv2SbywnCS8jQ==",
+            "version": "5.21.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.21.0.tgz",
+            "integrity": "sha512-XTX0g0IhvzcH/e3393SvjRCfYQxgxtYzL3UREteUneo72EFlt7UNoiYnikUtmGVobTbhUDByhJ4xRBNe+34kOQ==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/types": "5.18.0",
-                "@typescript-eslint/visitor-keys": "5.18.0"
+                "@typescript-eslint/types": "5.21.0",
+                "@typescript-eslint/visitor-keys": "5.21.0"
             }
         },
         "@typescript-eslint/type-utils": {
-            "version": "5.18.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.18.0.tgz",
-            "integrity": "sha512-vcn9/6J5D6jtHxpEJrgK8FhaM8r6J1/ZiNu70ZUJN554Y3D9t3iovi6u7JF8l/e7FcBIxeuTEidZDR70UuCIfA==",
+            "version": "5.21.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.21.0.tgz",
+            "integrity": "sha512-MxmLZj0tkGlkcZCSE17ORaHl8Th3JQwBzyXL/uvC6sNmu128LsgjTX0NIzy+wdH2J7Pd02GN8FaoudJntFvSOw==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/utils": "5.18.0",
+                "@typescript-eslint/utils": "5.21.0",
                 "debug": "^4.3.2",
                 "tsutils": "^3.21.0"
             }
         },
         "@typescript-eslint/types": {
-            "version": "5.18.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.18.0.tgz",
-            "integrity": "sha512-bhV1+XjM+9bHMTmXi46p1Led5NP6iqQcsOxgx7fvk6gGiV48c6IynY0apQb7693twJDsXiVzNXTflhplmaiJaw==",
+            "version": "5.21.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.21.0.tgz",
+            "integrity": "sha512-XnOOo5Wc2cBlq8Lh5WNvAgHzpjnEzxn4CJBwGkcau7b/tZ556qrWXQz4DJyChYg8JZAD06kczrdgFPpEQZfDsA==",
             "dev": true
         },
         "@typescript-eslint/typescript-estree": {
-            "version": "5.18.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.18.0.tgz",
-            "integrity": "sha512-wa+2VAhOPpZs1bVij9e5gyVu60ReMi/KuOx4LKjGx2Y3XTNUDJgQ+5f77D49pHtqef/klglf+mibuHs9TrPxdQ==",
+            "version": "5.21.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.21.0.tgz",
+            "integrity": "sha512-Y8Y2T2FNvm08qlcoSMoNchh9y2Uj3QmjtwNMdRQkcFG7Muz//wfJBGBxh8R7HAGQFpgYpdHqUpEoPQk+q9Kjfg==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/types": "5.18.0",
-                "@typescript-eslint/visitor-keys": "5.18.0",
+                "@typescript-eslint/types": "5.21.0",
+                "@typescript-eslint/visitor-keys": "5.21.0",
                 "debug": "^4.3.2",
                 "globby": "^11.0.4",
                 "is-glob": "^4.0.3",
@@ -7300,26 +7384,26 @@
             }
         },
         "@typescript-eslint/utils": {
-            "version": "5.18.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.18.0.tgz",
-            "integrity": "sha512-+hFGWUMMri7OFY26TsOlGa+zgjEy1ssEipxpLjtl4wSll8zy85x0GrUSju/FHdKfVorZPYJLkF3I4XPtnCTewA==",
+            "version": "5.21.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.21.0.tgz",
+            "integrity": "sha512-q/emogbND9wry7zxy7VYri+7ydawo2HDZhRZ5k6yggIvXa7PvBbAAZ4PFH/oZLem72ezC4Pr63rJvDK/sTlL8Q==",
             "dev": true,
             "requires": {
                 "@types/json-schema": "^7.0.9",
-                "@typescript-eslint/scope-manager": "5.18.0",
-                "@typescript-eslint/types": "5.18.0",
-                "@typescript-eslint/typescript-estree": "5.18.0",
+                "@typescript-eslint/scope-manager": "5.21.0",
+                "@typescript-eslint/types": "5.21.0",
+                "@typescript-eslint/typescript-estree": "5.21.0",
                 "eslint-scope": "^5.1.1",
                 "eslint-utils": "^3.0.0"
             }
         },
         "@typescript-eslint/visitor-keys": {
-            "version": "5.18.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.18.0.tgz",
-            "integrity": "sha512-Hf+t+dJsjAKpKSkg3EHvbtEpFFb/1CiOHnvI8bjHgOD4/wAw3gKrA0i94LrbekypiZVanJu3McWJg7rWDMzRTg==",
+            "version": "5.21.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.21.0.tgz",
+            "integrity": "sha512-SX8jNN+iHqAF0riZQMkm7e8+POXa/fXw5cxL+gjpyP+FI+JVNhii53EmQgDAfDcBpFekYSlO0fGytMQwRiMQCA==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/types": "5.18.0",
+                "@typescript-eslint/types": "5.21.0",
                 "eslint-visitor-keys": "^3.0.0"
             }
         },
@@ -7505,15 +7589,15 @@
             "dev": true
         },
         "abab": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.5.tgz",
-            "integrity": "sha512-9IK9EadsbHo6jLWIpxpR6pL0sazTXV6+SQv25ZB+F7Bj9mJNaOc4nCRabwd5M/JwmUa8idz6Eci6eKfJryPs6Q==",
+            "version": "2.0.6",
+            "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.6.tgz",
+            "integrity": "sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==",
             "dev": true
         },
         "acorn": {
-            "version": "8.7.0",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
-            "integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==",
+            "version": "8.7.1",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.1.tgz",
+            "integrity": "sha512-Xx54uLJQZ19lKygFXOWsscKUbsBZW0CPykPhVQdhIeIwrbPmJzqeASDInc8nKBnp/JT6igTs82qPXz069H8I/A==",
             "dev": true
         },
         "acorn-globals": {
@@ -7751,15 +7835,15 @@
             "dev": true
         },
         "browserslist": {
-            "version": "4.20.2",
-            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.20.2.tgz",
-            "integrity": "sha512-CQOBCqp/9pDvDbx3xfMi+86pr4KXIf2FDkTTdeuYw8OxS9t898LA1Khq57gtufFILXpfgsSx5woNgsBgvGjpsA==",
+            "version": "4.20.3",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.20.3.tgz",
+            "integrity": "sha512-NBhymBQl1zM0Y5dQT/O+xiLP9/rzOIQdKM/eMJBAq7yBgaB6krIYLGejrwVYnSHZdqjscB1SPuAjHwxjvN6Wdg==",
             "dev": true,
             "requires": {
-                "caniuse-lite": "^1.0.30001317",
-                "electron-to-chromium": "^1.4.84",
+                "caniuse-lite": "^1.0.30001332",
+                "electron-to-chromium": "^1.4.118",
                 "escalade": "^3.1.1",
-                "node-releases": "^2.0.2",
+                "node-releases": "^2.0.3",
                 "picocolors": "^1.0.0"
             }
         },
@@ -7800,9 +7884,9 @@
             "dev": true
         },
         "caniuse-lite": {
-            "version": "1.0.30001325",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001325.tgz",
-            "integrity": "sha512-sB1bZHjseSjDtijV1Hb7PB2Zd58Kyx+n/9EotvZ4Qcz2K3d0lWB8dB4nb8wN/TsOGFq3UuAm0zQZNQ4SoR7TrQ==",
+            "version": "1.0.30001332",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001332.tgz",
+            "integrity": "sha512-10T30NYOEQtN6C11YGg411yebhvpnC6Z102+B95eAsN0oB6KUs01ivE8u+G6FMIRtIrVlYXhL+LUwQ3/hXwDWw==",
             "dev": true
         },
         "chalk": {
@@ -8100,9 +8184,9 @@
             }
         },
         "electron-to-chromium": {
-            "version": "1.4.104",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.104.tgz",
-            "integrity": "sha512-2kjoAyiG7uMyGRM9mx25s3HAzmQG2ayuYXxsFmYugHSDcwxREgLtscZvbL1JcW9S/OemeQ3f/SG6JhDwpnCclQ==",
+            "version": "1.4.123",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.123.tgz",
+            "integrity": "sha512-0pHGE53WkYoFbsgwYcVKEpWa6jbzlvkohIEA2CUoZ9b5KC+w/zlMiQHvW/4IBcOh7YoEFqRNavgTk02TBoUTUw==",
             "dev": true
         },
         "emittery": {
@@ -8237,12 +8321,12 @@
             }
         },
         "eslint": {
-            "version": "8.12.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.12.0.tgz",
-            "integrity": "sha512-it1oBL9alZg1S8UycLm5YDMAkIhtH6FtAzuZs6YvoGVldWjbS08BkAdb/ymP9LlAyq8koANu32U7Ib/w+UNh8Q==",
+            "version": "8.14.0",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.14.0.tgz",
+            "integrity": "sha512-3/CE4aJX7LNEiE3i6FeodHmI/38GZtWCsAtsymScmzYapx8q1nVVb+eLcLSzATmCPXw5pT4TqVs1E0OmxAd9tw==",
             "dev": true,
             "requires": {
-                "@eslint/eslintrc": "^1.2.1",
+                "@eslint/eslintrc": "^1.2.2",
                 "@humanwhocodes/config-array": "^0.9.2",
                 "ajv": "^6.10.0",
                 "chalk": "^4.0.0",
@@ -8704,9 +8788,9 @@
             }
         },
         "https-proxy-agent": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
-            "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+            "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
             "dev": true,
             "requires": {
                 "agent-base": "6",
@@ -8803,9 +8887,9 @@
             "dev": true
         },
         "is-core-module": {
-            "version": "2.8.1",
-            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.1.tgz",
-            "integrity": "sha512-SdNCUs284hr40hFTFP6l0IfZ/RSrMXF3qgoRHd3/79unUTvrFO/JoXwkGm+5J/Oe3E/b5GsnG330uUNgRpu1PA==",
+            "version": "2.9.0",
+            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.9.0.tgz",
+            "integrity": "sha512-+5FPy5PnwmO3lvfMb0AsoPaBG+5KHUI0wYFXOtYPnVVVspTFUuMZNfNaNVRt3FZadstu2c8x23vykRW/NBoU6A==",
             "dev": true,
             "requires": {
                 "has": "^1.0.3"
@@ -8902,9 +8986,9 @@
             "dev": true
         },
         "istanbul-lib-instrument": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-5.1.0.tgz",
-            "integrity": "sha512-czwUz525rkOFDJxfKK6mYfIs9zBKILyrZQxjz3ABhjQXhbhFsSbo1HW/BFcsDnfJYJWA6thRR5/TUY2qs5W99Q==",
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-5.2.0.tgz",
+            "integrity": "sha512-6Lthe1hqXHBNsqvgDzGO6l03XNeu3CrG4RqQ1KM9+l5+jNGpEJfIELx1NS3SEHmJQA8np/u+E4EPRKRiu6m19A==",
             "dev": true,
             "requires": {
                 "@babel/core": "^7.12.3",
@@ -9607,9 +9691,9 @@
             "dev": true
         },
         "loader-runner": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.2.0.tgz",
-            "integrity": "sha512-92+huvxMvYlMzMt0iIOukcwYBFpkYJdpl2xsZ7LrlayO7E8SOv+JJUEK17B/dJIHAOLMfh2dZZ/Y18WgmGtYNw==",
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.0.tgz",
+            "integrity": "sha512-3R/1M+yS3j5ou80Me59j7F9IMs4PXs3VqRrm0TU3AbKPxlmpoY1TNscJV/oGJXo8qCatFGTfDbY6W6ipGOYXfg==",
             "dev": true
         },
         "loader-utils": {
@@ -9650,11 +9734,20 @@
             "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
             "dev": true
         },
-        "lru-cache": {
-            "version": "7.7.3",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.7.3.tgz",
-            "integrity": "sha512-WY9wjJNQt9+PZilnLbuFKM+SwDull9+6IAguOrarOMoOHTcJ9GnXSO11+Gw6c7xtDkBkthR57OZMtZKYr+1CEw==",
+        "lodash.sortby": {
+            "version": "4.7.0",
+            "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+            "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
             "dev": true
+        },
+        "lru-cache": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+            "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+            "dev": true,
+            "requires": {
+                "yallist": "^4.0.0"
+            }
         },
         "make-dir": {
             "version": "3.1.0",
@@ -9764,9 +9857,9 @@
             "dev": true
         },
         "nanoid": {
-            "version": "3.3.2",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.2.tgz",
-            "integrity": "sha512-CuHBogktKwpm5g2sRgv83jEy2ijFzBwMoYA60orPDR7ynsLijJDqgsi4RDGj3OJpy3Ieb+LYwiRmIOGyytgITA==",
+            "version": "3.3.3",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.3.tgz",
+            "integrity": "sha512-p1sjXuopFs0xg+fPASzQ28agW1oHD7xDsd9Xkf3T15H3c/cifrFHVwrh74PdoklAPi+i7MdRsE47vm2r6JoB+w==",
             "dev": true
         },
         "natural-compare": {
@@ -9812,9 +9905,9 @@
             "dev": true
         },
         "node-releases": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.2.tgz",
-            "integrity": "sha512-XxYDdcQ6eKqp/YjI+tb2C5WM2LgjnZrfYg4vgQt49EK268b6gYCHsBLrK2qvJo4FmCtqmKezb0WZFK4fkrZNsg==",
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.3.tgz",
+            "integrity": "sha512-maHFz6OLqYxz+VQyCAtA3PTX4UP/53pa05fyDNc9CwjvJ0yEh6+xBwKsgCxMNhS8taUKBFYxfuiaD9U/55iFaw==",
             "dev": true
         },
         "normalize-path": {
@@ -10291,12 +10384,12 @@
             }
         },
         "semver": {
-            "version": "7.3.6",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.6.tgz",
-            "integrity": "sha512-HZWqcgwLsjaX1HBD31msI/rXktuIhS+lWvdE4kN9z+8IVT4Itc7vqU2WvYsyD6/sjYCt4dEKH/m1M3dwI9CC5w==",
+            "version": "7.3.7",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+            "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
             "dev": true,
             "requires": {
-                "lru-cache": "^7.4.0"
+                "lru-cache": "^6.0.0"
             }
         },
         "serialize-javascript": {
@@ -10510,22 +10603,51 @@
             }
         },
         "terser": {
-            "version": "5.12.1",
-            "resolved": "https://registry.npmjs.org/terser/-/terser-5.12.1.tgz",
-            "integrity": "sha512-NXbs+7nisos5E+yXwAD+y7zrcTkMqb0dEJxIGtSKPdCBzopf7ni4odPul2aechpV7EXNvOudYOX2bb5tln1jbQ==",
+            "version": "5.13.0",
+            "resolved": "https://registry.npmjs.org/terser/-/terser-5.13.0.tgz",
+            "integrity": "sha512-sgQ99P+fRBM1jAYzN9RTnD/xEWx/7LZgYTCRgmYriSq1wxxqiQPJgXkkLBBuwySDWJ2PP0PnVQyuf4xLUuH4Ng==",
             "dev": true,
             "requires": {
                 "acorn": "^8.5.0",
                 "commander": "^2.20.0",
-                "source-map": "~0.7.2",
+                "source-map": "~0.8.0-beta.0",
                 "source-map-support": "~0.5.20"
             },
             "dependencies": {
                 "source-map": {
-                    "version": "0.7.3",
-                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
-                    "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
+                    "version": "0.8.0-beta.0",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.8.0-beta.0.tgz",
+                    "integrity": "sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA==",
+                    "dev": true,
+                    "requires": {
+                        "whatwg-url": "^7.0.0"
+                    }
+                },
+                "tr46": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
+                    "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
+                    "dev": true,
+                    "requires": {
+                        "punycode": "^2.1.0"
+                    }
+                },
+                "webidl-conversions": {
+                    "version": "4.0.2",
+                    "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
+                    "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
                     "dev": true
+                },
+                "whatwg-url": {
+                    "version": "7.1.0",
+                    "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
+                    "integrity": "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==",
+                    "dev": true,
+                    "requires": {
+                        "lodash.sortby": "^4.7.0",
+                        "tr46": "^1.0.1",
+                        "webidl-conversions": "^4.0.2"
+                    }
                 }
             }
         },
@@ -10623,9 +10745,9 @@
             }
         },
         "ts-loader": {
-            "version": "8.3.0",
-            "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-8.3.0.tgz",
-            "integrity": "sha512-MgGly4I6cStsJy27ViE32UoqxPTN9Xly4anxxVyaIWR+9BGxboV4EyJBGfR3RePV7Ksjj3rHmPZJeIt+7o4Vag==",
+            "version": "8.4.0",
+            "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-8.4.0.tgz",
+            "integrity": "sha512-6nFY3IZ2//mrPc+ImY3hNWx1vCHyEhl6V+wLmL4CZcm6g1CqX7UKrkc6y0i4FwcfOhxyMPCfaEvh20f4r9GNpw==",
             "dev": true,
             "requires": {
                 "chalk": "^4.1.0",
@@ -10636,9 +10758,9 @@
             }
         },
         "tslib": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-            "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+            "version": "2.4.0",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+            "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
             "dev": true
         },
         "tsutils": {
@@ -10784,9 +10906,9 @@
             "dev": true
         },
         "webpack": {
-            "version": "5.71.0",
-            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.71.0.tgz",
-            "integrity": "sha512-g4dFT7CFG8LY0iU5G8nBL6VlkT21Z7dcYDpJAEJV5Q1WLb9UwnFbrem1k7K52ILqEmomN7pnzWFxxE6SlDY56A==",
+            "version": "5.72.0",
+            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.72.0.tgz",
+            "integrity": "sha512-qmSmbspI0Qo5ld49htys8GY9XhS9CGqFoHTsOVAnjBdg0Zn79y135R+k4IR4rKK6+eKaabMhJwiVB7xw0SJu5w==",
             "dev": true,
             "requires": {
                 "@types/eslint-scope": "^3.7.3",
@@ -10816,9 +10938,9 @@
             },
             "dependencies": {
                 "enhanced-resolve": {
-                    "version": "5.9.2",
-                    "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.9.2.tgz",
-                    "integrity": "sha512-GIm3fQfwLJ8YZx2smuHpBKkXC1yOk+OBEmKckVyL0i/ea8mqDEykK3ld5dgH1QYPNyT/lIllxV2LULnxCHaHkA==",
+                    "version": "5.9.3",
+                    "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.9.3.tgz",
+                    "integrity": "sha512-Bq9VSor+kjvW3f9/MiiR4eE3XYgOl7/rS8lnSxbRbF3kS0B2r+Y9w5krBWxZgDxASVZbdYrn5wT4j/Wb0J9qow==",
                     "dev": true,
                     "requires": {
                         "graceful-fs": "^4.2.4",
@@ -10976,6 +11098,12 @@
             "version": "5.0.8",
             "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
             "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+            "dev": true
+        },
+        "yallist": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
             "dev": true
         },
         "yargs": {

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "ringofsnakes-client",
-    "version": "0.4.0",
+    "version": "0.4.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "ringofsnakes-client",
-            "version": "0.4.0",
+            "version": "0.4.1",
             "dependencies": {
                 "comlink": "^4.3.1",
                 "preact": "^10.6.6"

--- a/client/package.json
+++ b/client/package.json
@@ -9,10 +9,11 @@
     "private": true,
     "scripts": {
         "test": "jest --maxWorkers=1",
+        "pack:shaders": "node pack-shaders.js",
         "build:js": "webpack --config webpack.config.js",
         "build:js:watch": "webpack --watch --config webpack.config.js",
-        "build": "npm run build:js",
-        "build:production": "webpack --config webpack.config.production.js",
+        "build": "npm run pack:shaders && npm run build:js",
+        "build:production": "npm run pack:shaders && webpack --config webpack.config.production.js",
         "format": "prettier --write \"src/**/*.ts\" \"src/**/*.tsx\"",
         "lint": "eslint ./src/app --ext .ts,.tsx",
         "check:format": "prettier --check --no-color \"src/**/*.ts\" \"src/**/*.tsx\"",

--- a/client/package.json
+++ b/client/package.json
@@ -10,7 +10,7 @@
     "scripts": {
         "test": "jest --maxWorkers=1",
         "pack:shaders": "node pack-shaders.js",
-        "build:js": "webpack --config webpack.config.js",
+        "build:js": "webpack --config webpack.config.js --progress",
         "build:js:watch": "webpack --watch --config webpack.config.js",
         "build": "npm run pack:shaders && npm run build:js",
         "build:production": "npm run pack:shaders && webpack --config webpack.config.production.js",
@@ -19,7 +19,7 @@
         "check:format": "prettier --check --no-color \"src/**/*.ts\" \"src/**/*.tsx\"",
         "coverage": "jest --maxWorkers=1 --coverage"
     },
-    "author": "Tim Weißenfels",
+    "author": "KielerGames",
     "devDependencies": {
         "@types/jest": "^27.4.1",
         "@typescript-eslint/eslint-plugin": "^5.15.0",

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ringofsnakes-client",
-    "version": "0.4.0",
+    "version": "0.4.1",
     "description": "",
     "repository": {
         "type": "git",

--- a/client/src/app/renderer/modules/BoxRenderer.ts
+++ b/client/src/app/renderer/modules/BoxRenderer.ts
@@ -3,9 +3,7 @@ import { TransferableBox } from "../../math/Rectangle";
 import assert from "../../util/assert";
 import WebGLShaderProgram from "../webgl/WebGLShaderProgram";
 import * as WebGLContextProvider from "../webgl/WebGLContextProvider";
-
-declare const __VERTEXSHADER_SOLIDCOLOR__: string;
-declare const __FRAGMENTSHADER_SOLIDCOLOR__: string;
+import { getShaderSource } from "../webgl/ShaderLoader";
 
 let shader: WebGLShaderProgram;
 let buffer: WebGLBuffer;
@@ -15,7 +13,11 @@ const boxesToDraw: { box: TransferableBox; color: RGBAColor }[] = [];
 (async () => {
     const gl = await WebGLContextProvider.waitForContext();
 
-    shader = new WebGLShaderProgram(gl, __VERTEXSHADER_SOLIDCOLOR__, __FRAGMENTSHADER_SOLIDCOLOR__);
+    shader = new WebGLShaderProgram(
+        gl,
+        await getShaderSource("solidcolor.vert"),
+        await getShaderSource("solidcolor.frag")
+    );
 
     buffer = gl.createBuffer()!;
     assert(buffer !== null);

--- a/client/src/app/renderer/modules/BoxRenderer.ts
+++ b/client/src/app/renderer/modules/BoxRenderer.ts
@@ -3,7 +3,7 @@ import { TransferableBox } from "../../math/Rectangle";
 import assert from "../../util/assert";
 import WebGLShaderProgram from "../webgl/WebGLShaderProgram";
 import * as WebGLContextProvider from "../webgl/WebGLContextProvider";
-import { getShaderSource } from "../webgl/ShaderLoader";
+import { compileShader } from "../webgl/ShaderLoader";
 
 let shader: WebGLShaderProgram;
 let buffer: WebGLBuffer;
@@ -13,11 +13,7 @@ const boxesToDraw: { box: TransferableBox; color: RGBAColor }[] = [];
 (async () => {
     const gl = await WebGLContextProvider.waitForContext();
 
-    shader = new WebGLShaderProgram(
-        gl,
-        await getShaderSource("solidcolor.vert"),
-        await getShaderSource("solidcolor.frag")
-    );
+    shader = await compileShader(gl, "solidcolor");
 
     buffer = gl.createBuffer()!;
     assert(buffer !== null);

--- a/client/src/app/renderer/modules/FoodRenderer.ts
+++ b/client/src/app/renderer/modules/FoodRenderer.ts
@@ -5,7 +5,7 @@ import Vector from "../../math/Vector";
 import WebGLShaderProgram from "../webgl/WebGLShaderProgram";
 import * as BoxRenderer from "./BoxRenderer";
 import * as WebGLContextProvider from "../webgl/WebGLContextProvider";
-import { getShaderSource } from "../webgl/ShaderLoader";
+import { compileShader } from "../webgl/ShaderLoader";
 
 let shader: WebGLShaderProgram;
 
@@ -14,13 +14,7 @@ const FAR_AWAY = new Vector(Number.POSITIVE_INFINITY, Number.POSITIVE_INFINITY);
 
 (async () => {
     const gl = await WebGLContextProvider.waitForContext();
-
-    shader = new WebGLShaderProgram(
-        gl,
-        await getShaderSource("food.vert"),
-        await getShaderSource("food.frag"),
-        ["aPosition", "aLocalPos", "aColorIndex"]
-    );
+    shader = await compileShader(gl, "food", ["aPosition", "aLocalPos", "aColorIndex"]);
 })();
 
 export function render(game: Readonly<Game>, transform: ReadonlyMatrix) {

--- a/client/src/app/renderer/modules/FoodRenderer.ts
+++ b/client/src/app/renderer/modules/FoodRenderer.ts
@@ -5,9 +5,7 @@ import Vector from "../../math/Vector";
 import WebGLShaderProgram from "../webgl/WebGLShaderProgram";
 import * as BoxRenderer from "./BoxRenderer";
 import * as WebGLContextProvider from "../webgl/WebGLContextProvider";
-
-declare const __VERTEXSHADER_FOOD__: string;
-declare const __FRAGMENTSHADER_FOOD__: string;
+import { getShaderSource } from "../webgl/ShaderLoader";
 
 let shader: WebGLShaderProgram;
 
@@ -17,11 +15,12 @@ const FAR_AWAY = new Vector(Number.POSITIVE_INFINITY, Number.POSITIVE_INFINITY);
 (async () => {
     const gl = await WebGLContextProvider.waitForContext();
 
-    shader = new WebGLShaderProgram(gl, __VERTEXSHADER_FOOD__, __FRAGMENTSHADER_FOOD__, [
-        "aPosition",
-        "aLocalPos",
-        "aColorIndex"
-    ]);
+    shader = new WebGLShaderProgram(
+        gl,
+        await getShaderSource("food.vert"),
+        await getShaderSource("food.frag"),
+        ["aPosition", "aLocalPos", "aColorIndex"]
+    );
 })();
 
 export function render(game: Readonly<Game>, transform: ReadonlyMatrix) {

--- a/client/src/app/renderer/modules/HeatMapRenderer.ts
+++ b/client/src/app/renderer/modules/HeatMapRenderer.ts
@@ -4,9 +4,7 @@ import * as WebGLContextProvider from "../webgl/WebGLContextProvider";
 import assert from "../../util/assert";
 import Vector from "../../math/Vector";
 import Matrix from "../../math/Matrix";
-
-declare const __VERTEXSHADER_HEATMAP__: string;
-declare const __FRAGMENTSHADER_HEATMAP__: string;
+import { getShaderSource } from "../webgl/ShaderLoader";
 
 const transform = new Matrix(true);
 let shaderProgram: WebGLShaderProgram;
@@ -32,8 +30,8 @@ const heatMapSize = 128;
 
     shaderProgram = new WebGLShaderProgram(
         gl,
-        __VERTEXSHADER_HEATMAP__,
-        __FRAGMENTSHADER_HEATMAP__
+        await getShaderSource("heatmap.vert"),
+        await getShaderSource("heatmap.frag")
     );
 
     buffer = gl.createBuffer()!;

--- a/client/src/app/renderer/modules/HeatMapRenderer.ts
+++ b/client/src/app/renderer/modules/HeatMapRenderer.ts
@@ -4,7 +4,7 @@ import * as WebGLContextProvider from "../webgl/WebGLContextProvider";
 import assert from "../../util/assert";
 import Vector from "../../math/Vector";
 import Matrix from "../../math/Matrix";
-import { getShaderSource } from "../webgl/ShaderLoader";
+import { compileShader } from "../webgl/ShaderLoader";
 
 const transform = new Matrix(true);
 let shaderProgram: WebGLShaderProgram;
@@ -28,11 +28,7 @@ const heatMapSize = 128;
 (async () => {
     const gl = await WebGLContextProvider.waitForContext();
 
-    shaderProgram = new WebGLShaderProgram(
-        gl,
-        await getShaderSource("heatmap.vert"),
-        await getShaderSource("heatmap.frag")
-    );
+    shaderProgram = await compileShader(gl, "heatmap");
 
     buffer = gl.createBuffer()!;
     assert(buffer !== null);

--- a/client/src/app/renderer/modules/SnakeChunkRenderer.ts
+++ b/client/src/app/renderer/modules/SnakeChunkRenderer.ts
@@ -7,9 +7,7 @@ import * as SkinLoader from "../SkinLoader";
 import assert from "../../util/assert";
 import Game from "../../data/Game";
 import Vector from "../../math/Vector";
-
-declare const __VERTEXSHADER_SNAKE__: string;
-declare const __FRAGMENTSHADER_SNAKE__: string;
+import { getShaderSource } from "../webgl/ShaderLoader";
 
 let basicMaterialShader: WebGLShaderProgram;
 let buffer: WebGLBuffer;
@@ -19,8 +17,8 @@ let buffer: WebGLBuffer;
 
     basicMaterialShader = new WebGLShaderProgram(
         gl,
-        __VERTEXSHADER_SNAKE__,
-        __FRAGMENTSHADER_SNAKE__,
+        await getShaderSource("snake.vert"),
+        await getShaderSource("snake.frag"),
         ["aPosition", "aNormal", "aNormalOffset", "aRelativePathOffset"]
     );
 

--- a/client/src/app/renderer/modules/SnakeChunkRenderer.ts
+++ b/client/src/app/renderer/modules/SnakeChunkRenderer.ts
@@ -7,7 +7,7 @@ import * as SkinLoader from "../SkinLoader";
 import assert from "../../util/assert";
 import Game from "../../data/Game";
 import Vector from "../../math/Vector";
-import { getShaderSource } from "../webgl/ShaderLoader";
+import { compileShader } from "../webgl/ShaderLoader";
 
 let basicMaterialShader: WebGLShaderProgram;
 let buffer: WebGLBuffer;
@@ -15,12 +15,12 @@ let buffer: WebGLBuffer;
 (async () => {
     const gl = await WebGLContextProvider.waitForContext();
 
-    basicMaterialShader = new WebGLShaderProgram(
-        gl,
-        await getShaderSource("snake.vert"),
-        await getShaderSource("snake.frag"),
-        ["aPosition", "aNormal", "aNormalOffset", "aRelativePathOffset"]
-    );
+    basicMaterialShader = await compileShader(gl, "snake", [
+        "aPosition",
+        "aNormal",
+        "aNormalOffset",
+        "aRelativePathOffset"
+    ]);
 
     buffer = gl.createBuffer()!;
     assert(buffer !== null);

--- a/client/src/app/renderer/modules/SnakeHeadRenderer.ts
+++ b/client/src/app/renderer/modules/SnakeHeadRenderer.ts
@@ -4,7 +4,7 @@ import * as SkinManager from "../SkinLoader";
 import * as WebGLContextProvider from "../webgl/WebGLContextProvider";
 import assert from "../../util/assert";
 import Game from "../../data/Game";
-import { getShaderSource } from "../webgl/ShaderLoader";
+import { compileShader } from "../webgl/ShaderLoader";
 
 let buffer: WebGLBuffer;
 let shader: WebGLShaderProgram;
@@ -23,11 +23,7 @@ const rotOffset = -0.5 * Math.PI;
     buffer = gl.createBuffer()!;
     assert(buffer !== null);
 
-    shader = new WebGLShaderProgram(
-        gl,
-        await getShaderSource("head.vert"),
-        await getShaderSource("head.frag")
-    );
+    shader = await compileShader(gl, "head");
 
     // send data to GPU (once)
     shader.use();

--- a/client/src/app/renderer/modules/SnakeHeadRenderer.ts
+++ b/client/src/app/renderer/modules/SnakeHeadRenderer.ts
@@ -4,9 +4,7 @@ import * as SkinManager from "../SkinLoader";
 import * as WebGLContextProvider from "../webgl/WebGLContextProvider";
 import assert from "../../util/assert";
 import Game from "../../data/Game";
-
-declare const __VERTEXSHADER_HEAD__: string;
-declare const __FRAGMENTSHADER_HEAD__: string;
+import { getShaderSource } from "../webgl/ShaderLoader";
 
 let buffer: WebGLBuffer;
 let shader: WebGLShaderProgram;
@@ -25,7 +23,11 @@ const rotOffset = -0.5 * Math.PI;
     buffer = gl.createBuffer()!;
     assert(buffer !== null);
 
-    shader = new WebGLShaderProgram(gl, __VERTEXSHADER_HEAD__, __FRAGMENTSHADER_HEAD__);
+    shader = new WebGLShaderProgram(
+        gl,
+        await getShaderSource("head.vert"),
+        await getShaderSource("head.frag")
+    );
 
     // send data to GPU (once)
     shader.use();

--- a/client/src/app/renderer/webgl/ShaderLoader.ts
+++ b/client/src/app/renderer/webgl/ShaderLoader.ts
@@ -59,6 +59,11 @@ async function getShaderSource(filename: Filename): Promise<ShaderSource> {
     return shaders.get(filename)!;
 }
 
+/**
+ * Compiles the shader using the code defined in
+ *  - src/shader/${name}.vert (vertex shader)
+ *  - src/shader/${name}.frag (fragment shader)
+ */
 export async function compileShader(
     gl: WebGLRenderingContext,
     name: string,

--- a/client/src/app/renderer/webgl/ShaderLoader.ts
+++ b/client/src/app/renderer/webgl/ShaderLoader.ts
@@ -11,7 +11,7 @@ const shaders = new Map<Filename, ShaderSource>();
 const loaded = new AsyncEvent();
 
 (async () => {
-    const filePath = "shaders.json?v=" + __VERSION__;
+    const filePath = "shaders.json?h=" + __SHADER_HASH__;
     const shaderData = await loadJSON<JSONData>(filePath, {
         guard: function (data: unknown): data is JSONData {
             if (typeof data !== "object") {

--- a/client/src/app/renderer/webgl/ShaderLoader.ts
+++ b/client/src/app/renderer/webgl/ShaderLoader.ts
@@ -1,0 +1,58 @@
+import AsyncEvent from "../../util/AsyncEvent";
+import { loadJSON } from "../../util/JSONLoader";
+
+type Filename = string;
+type ShaderSource = string;
+type JSONData = Record<Filename, ShaderSource>;
+
+const shaders = new Map<Filename, ShaderSource>();
+const loaded = new AsyncEvent();
+
+(async () => {
+    const filePath = "shaders.json?v=" + __VERSION__;
+    const shaderData = await loadJSON<JSONData>(filePath, {
+        guard: function (data: unknown): data is JSONData {
+            if (typeof data !== "object") {
+                return false;
+            }
+
+            for (const [key, value] of Object.entries(data!)) {
+                if (typeof key !== "string" || typeof value !== "string") {
+                    return false;
+                }
+
+                if (__DEBUG__) {
+                    if (!/[A-Za-z_]\w+\.(vert|frag)/.test(key)) {
+                        return false;
+                    }
+
+                    if (value.trim() === "") {
+                        return false;
+                    }
+                }
+            }
+
+            return true;
+        }
+    });
+
+    for (const [key, value] of Object.entries(shaderData)) {
+        shaders.set(key, value);
+    }
+
+    loaded.set();
+})();
+
+/**
+ * Load the shader code defined in src/shader/${filename}.
+ * Does not load the file directly, shaders must be packed in public/shaders.json.
+ */
+export async function getShaderSource(filename: Filename): Promise<ShaderSource> {
+    await loaded.wait();
+
+    if (!shaders.has(filename)) {
+        return Promise.reject(new Error(`Shader ${filename} not found.`));
+    }
+
+    return shaders.get(filename)!;
+}

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -4,28 +4,6 @@
 const webpack = require("webpack");
 const path = require("path");
 const pkg = require("./package.json");
-const fs = require("fs");
-
-const SHADER_DIR = "src/shader";
-const shaders = {};
-
-console.log("Loading shaders...");
-let shaderFiles = fs.readdirSync(SHADER_DIR);
-shaderFiles.forEach((filename) => {
-    if (filename.endsWith(".vert") || filename.endsWith(".frag")) {
-        console.log(" --> " + filename);
-        let content = fs.readFileSync(SHADER_DIR + "/" + filename, "utf8");
-        content = JSON.stringify(content.trim());
-
-        let stn = filename.endsWith(".vert")
-            ? "VERTEXSHADER"
-            : "FRAGMENTSHADER";
-        let id = filename.slice(0, filename.length - 5).toUpperCase();
-
-        shaders["__" + stn + "_" + id + "__"] = content;
-    }
-});
-console.log("Done. Running webpack...");
 
 module.exports = {
     mode: "development",
@@ -58,16 +36,11 @@ module.exports = {
         ]
     },
     plugins: [
-        new webpack.DefinePlugin(
-            Object.assign(
-                {
-                    __VERSION__: JSON.stringify(`${pkg.version}-dev`),
-                    __DEBUG__: "true",
-                    __TEST__: "false"
-                },
-                shaders
-            )
-        )
+        new webpack.DefinePlugin({
+            __VERSION__: JSON.stringify(`${pkg.version}-dev`),
+            __DEBUG__: "true",
+            __TEST__: "false"
+        })
     ],
     output: {
         filename: "[name].bundle.js",

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -2,8 +2,18 @@
 /* eslint-disable no-undef */
 
 const webpack = require("webpack");
-const path = require("path");
+const path = require("node:path");
+const fs = require("node:fs");
+const crypto = require("node:crypto");
 const pkg = require("./package.json");
+
+const SHADER_HASH = (() => {
+    const fileBuffer = fs.readFileSync(path.join("public", "shaders.json"));
+    const hashSum = crypto.createHash("sha256");
+    hashSum.update(fileBuffer);
+
+    return hashSum.digest("hex").substring(0, 10);
+})();
 
 module.exports = {
     mode: "development",
@@ -38,6 +48,7 @@ module.exports = {
     plugins: [
         new webpack.DefinePlugin({
             __VERSION__: JSON.stringify(`${pkg.version}-dev`),
+            __SHADER_HASH__: JSON.stringify(SHADER_HASH),
             __DEBUG__: "true",
             __TEST__: "false"
         })

--- a/client/webpack.config.production.js
+++ b/client/webpack.config.production.js
@@ -4,38 +4,16 @@
 const webpack = require("webpack");
 const path = require("path");
 const pkg = require("./package.json");
-const fs = require("fs");
-
-const SHADER_DIR = "src/shader";
-const shaders = {};
-
-console.log("Loading shaders...");
-let shaderFiles = fs.readdirSync(SHADER_DIR);
-shaderFiles.forEach((filename) => {
-    if (filename.endsWith(".vert") || filename.endsWith(".frag")) {
-        console.log(" --> " + filename);
-        let content = fs.readFileSync(SHADER_DIR + "/" + filename, "utf8");
-        content = JSON.stringify(content.trim());
-
-        let stn = filename.endsWith(".vert")
-            ? "VERTEXSHADER"
-            : "FRAGMENTSHADER";
-        let id = filename.slice(0, filename.length - 5).toUpperCase();
-
-        shaders["__" + stn + "_" + id + "__"] = content;
-    }
-});
-console.log("Done. Running webpack...");
 
 module.exports = {
     mode: "production",
     entry: {
         main: path.join(__dirname, "src", "app", "main.tsx"),
-        worker: path.join(__dirname, "src", "app", "worker", "worker.ts"),
+        worker: path.join(__dirname, "src", "app", "worker", "worker.ts")
     },
     target: "web",
     resolve: {
-        extensions: [".ts", ".tsx", ".js"],
+        extensions: [".ts", ".tsx", ".js"]
     },
     module: {
         rules: [
@@ -43,33 +21,28 @@ module.exports = {
                 test: /\.tsx?$/,
                 loader: "ts-loader",
                 options: {
-                    onlyCompileBundledFiles: true,
-                },
+                    onlyCompileBundledFiles: true
+                }
             },
             {
                 test: /\.less$/i,
                 use: [
                     { loader: "style-loader" }, //  creates style nodes from JS strings
                     { loader: "css-loader" }, //    translates CSS into a JS module (CommonJS)
-                    { loader: "less-loader" }, //   compiles Less to CSS
-                ],
-            },
-        ],
+                    { loader: "less-loader" } //   compiles Less to CSS
+                ]
+            }
+        ]
     },
     plugins: [
-        new webpack.DefinePlugin(
-            Object.assign(
-                {
-                    __VERSION__: JSON.stringify(pkg.version),
-                    __DEBUG__: "false",
-                    __TEST__: "false"
-                },
-                shaders
-            )
-        ),
+        new webpack.DefinePlugin({
+            __VERSION__: JSON.stringify(pkg.version),
+            __DEBUG__: "false",
+            __TEST__: "false"
+        })
     ],
     output: {
         filename: "[name].bundle.js",
-        path: path.resolve(__dirname, "public"),
-    },
+        path: path.resolve(__dirname, "public")
+    }
 };

--- a/client/webpack.config.production.js
+++ b/client/webpack.config.production.js
@@ -2,8 +2,18 @@
 /* eslint-disable no-undef */
 
 const webpack = require("webpack");
-const path = require("path");
+const path = require("node:path");
+const fs = require("node:fs");
+const crypto = require("node:crypto");
 const pkg = require("./package.json");
+
+const SHADER_HASH = (() => {
+    const fileBuffer = fs.readFileSync(path.join("public", "shaders.json"));
+    const hashSum = crypto.createHash("sha256");
+    hashSum.update(fileBuffer);
+
+    return hashSum.digest("hex").substring(0, 10);
+})();
 
 module.exports = {
     mode: "production",
@@ -37,6 +47,7 @@ module.exports = {
     plugins: [
         new webpack.DefinePlugin({
             __VERSION__: JSON.stringify(pkg.version),
+            __SHADER_HASH__: JSON.stringify(SHADER_HASH),
             __DEBUG__: "false",
             __TEST__: "false"
         })


### PR DESCRIPTION
Shaders used to be packed as strings into the main JavaScript bundle. With this PR shaders are packed into a separate file `shaders.json` which gets loaded by `ShaderLoader.ts`. Since the shader code does not change very often this file can be cached by the browser. Also shaders are (or will) not be required for the initial page render, so this can help improve some performance metrics.

Another change in this PR: If there is a shader compile error an error message is shown to the user.