### PR TITLE
SnakeChunk rendering improvements

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "ringofsnakes-client",
-    "version": "0.6.1",
+    "version": "0.7.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "ringofsnakes-client",
-            "version": "0.6.1",
+            "version": "0.7.0",
             "dependencies": {
                 "comlink": "^4.3.1",
                 "preact": "^10.10.2"

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ringofsnakes-client",
-    "version": "0.6.1",
+    "version": "0.7.0",
     "description": "",
     "repository": {
         "type": "git",

--- a/client/src/app/data/Game.ts
+++ b/client/src/app/data/Game.ts
@@ -135,7 +135,9 @@ export default class Game {
                 continue;
             }
 
-            for (const snakeChunk of snake.getSnakeChunksIterator()) {
+            // To avoid concurrent modification errors we have to copy the array here.
+            const snakeChunks = Array.from(snake.getSnakeChunksIterator());
+            for (const snakeChunk of snakeChunks) {
                 this.snakeChunks.remove(snakeChunk.id);
             }
 

--- a/client/src/app/data/Game.ts
+++ b/client/src/app/data/Game.ts
@@ -33,6 +33,9 @@ export default class Game {
     private stopped: boolean = false;
 
     private readonly events = {
+        /**
+         * Fired if a snake that the client knows dies.
+         */
         snakeDeath: new AppEvent<Snake>()
     };
 
@@ -132,8 +135,6 @@ export default class Game {
                 continue;
             }
 
-            this.events.snakeDeath.trigger(snake);
-
             for (const snakeChunk of snake.getSnakeChunksIterator()) {
                 this.snakeChunks.remove(snakeChunk.id);
             }
@@ -143,6 +144,8 @@ export default class Game {
             if (snakeId === this.targetSnakeId) {
                 this.targetSnakeId = undefined;
             }
+
+            this.events.snakeDeath.trigger(snake);
         }
 
         const updatedSnakeIds = new Set<SnakeId>(changes.snakes.map((snake) => snake.id));
@@ -218,4 +221,4 @@ type SnakeId = number;
 type SnakeChunkId = number;
 type FoodChunkId = number;
 
-type EventName = "snakeDeath";
+type EventName = keyof Game["events"];

--- a/client/src/app/data/Game.ts
+++ b/client/src/app/data/Game.ts
@@ -205,7 +205,8 @@ export default class Game {
         const safeDist = 2 * this._config.snakes.fastSpeed;
 
         this.snakeChunks.removeIf(
-            (chunk) => chunk.junk || (!chunk.isVisible(camera, safeDist) && chunk.clientAge > 1.0)
+            (chunk) =>
+                chunk.junk || (!chunk.couldBeVisible(camera, safeDist) && chunk.clientAge > 1.0)
         );
 
         this.foodChunks.removeIf((chunk) => !chunk.isVisible(camera, safeDist) && chunk.age > 1.0);
@@ -214,7 +215,7 @@ export default class Game {
             (snake) =>
                 snake.id !== this.targetSnakeId &&
                 !snake.hasChunks() &&
-                !snake.isVisible(camera, safeDist)
+                !snake.couldBeVisible(camera, safeDist)
         );
     }
 }

--- a/client/src/app/data/snake/Snake.ts
+++ b/client/src/app/data/snake/Snake.ts
@@ -177,11 +177,13 @@ export default class Snake implements ManagedObject<number, SnakeDTO, number> {
     }
 
     /**
-     * True if the snake or some of its body is visible.
+     * True if any of the snakes bounding boxes intersect with the viewport.
+     * The snake could still be not visible though. If this method returns
+     * false the snake cannot be visible.
      */
-    isVisible(camera: Camera, epsilon: number = 0.0): boolean {
+    couldBeVisible(camera: Camera, epsilon: number = 0.0): boolean {
         for (const chunk of this.chunks) {
-            if (chunk.isVisible(camera, epsilon)) {
+            if (chunk.couldBeVisible(camera, epsilon)) {
                 return true;
             }
         }

--- a/client/src/app/data/snake/Snake.ts
+++ b/client/src/app/data/snake/Snake.ts
@@ -151,7 +151,9 @@ export default class Snake implements ManagedObject<number, SnakeDTO, number> {
     unregisterSnakeChunk(chunk: SnakeChunk): void {
         const i = this.chunks.findIndex((c) => c === chunk);
         if (i < 0) {
-            throw new Error(`Cannot unregister: Snake ${this.id} has no chunk with id ${chunk.id}.`);
+            throw new Error(
+                `Cannot unregister: Snake ${this.id} has no chunk with id ${chunk.id}.`
+            );
         }
         this.chunkIds.delete(chunk.id);
         this.chunks.splice(i, 1);
@@ -159,7 +161,7 @@ export default class Snake implements ManagedObject<number, SnakeDTO, number> {
 
     /**
      * Intended for iterating over SnakeChunks. You may not remove
-     * SnakeChunks during this iteration, that causes SnakeChunks 
+     * SnakeChunks during this iteration, that causes SnakeChunks
      * to be skipped.
      */
     getSnakeChunksIterator(): IterableIterator<SnakeChunk> {

--- a/client/src/app/data/snake/Snake.ts
+++ b/client/src/app/data/snake/Snake.ts
@@ -92,9 +92,8 @@ export default class Snake implements ManagedObject<number, SnakeDTO, number> {
         }
 
         // fix head chunk mesh
-        const headChunk = this.headChunk;
-        if (headChunk) {
-            headChunk.connectMeshToHead();
+        if (this.headChunk) {
+            this.headChunk.connectMeshToHead();
         }
 
         this.lastPredictionTime = FrameTime.now();
@@ -152,15 +151,17 @@ export default class Snake implements ManagedObject<number, SnakeDTO, number> {
     unregisterSnakeChunk(chunk: SnakeChunk): void {
         const i = this.chunks.findIndex((c) => c === chunk);
         if (i < 0) {
-            if (__DEBUG__) {
-                console.warn(`Snake ${this.id} has no chunk with id ${chunk.id}.`);
-            }
-            return;
+            throw new Error(`Cannot unregister: Snake ${this.id} has no chunk with id ${chunk.id}.`);
         }
         this.chunkIds.delete(chunk.id);
         this.chunks.splice(i, 1);
     }
 
+    /**
+     * Intended for iterating over SnakeChunks. You may not remove
+     * SnakeChunks during this iteration, that causes SnakeChunks 
+     * to be skipped.
+     */
     getSnakeChunksIterator(): IterableIterator<SnakeChunk> {
         return this.chunks.values();
     }

--- a/client/src/app/data/snake/SnakeChunk.ts
+++ b/client/src/app/data/snake/SnakeChunk.ts
@@ -127,7 +127,7 @@ export default class SnakeChunk implements ManagedObject<number, SnakeChunkDTO> 
         vb[vbo1 + 5] = vb[vbo2 + 5];
     }
 
-    isVisible(camera: Camera, epsilon: number = 0.0): boolean {
+    couldBeVisible(camera: Camera, epsilon: number = 0.0): boolean {
         const d = Rectangle.distance2(camera.viewBox, this.bounds);
         const ub = 0.5 * this.snake.width + epsilon;
         return d <= ub * ub;

--- a/client/src/app/renderer/modules/SnakeChunkRenderer.ts
+++ b/client/src/app/renderer/modules/SnakeChunkRenderer.ts
@@ -52,7 +52,7 @@ export function render(game: Readonly<Game>, transform: ReadonlyMatrix): void {
         // chunk will be last. Therefore newer chunks will be rendered
         // on top of older chunks.
         for (const chunk of snake.getSnakeChunksIterator()) {
-            if (!chunk.isVisible(camera)) {
+            if (!chunk.couldBeVisible(camera)) {
                 continue;
             }
 


### PR DESCRIPTION
Instead of a `Map<SnakeChunk["id"], SnakeChunk>` data structure, `Snake`s now use both an array `SnakeChunk[]` and a `Set<SnakeChunk["id"]>` to keep those chunks in a certain order (for rendering) and still allow quick existence checks.

`SnakeChunkRenderer` now iterates over `Snake`s first and then over the `Snake`s chunks to make sure chunks are rendered in the correct order (sorted by id) so that the bug described in #228 can not occur anymore. 

Also reduced data transfer to the GPU by reusing buffers #19 and renamed `isVisible` methods to `couldBeVisible`.

Closes #228. 
Closes #19.