### PR TITLE
Tracking kills

### DIFF
--- a/client/.eslintrc.json
+++ b/client/.eslintrc.json
@@ -4,26 +4,32 @@
     "plugins": ["@typescript-eslint"],
     "extends": ["eslint:recommended", "plugin:@typescript-eslint/recommended"],
     "rules": {
-        "no-console": "off",
-        "@typescript-eslint/no-non-null-assertion": "off",
-        "@typescript-eslint/no-inferrable-types": "off",
-        "no-empty-function": "off",
-        "@typescript-eslint/no-empty-function": "warn",
+        "no-alert": "warn",
         "no-bitwise": "error",
+        "no-console": "off",
+        "no-constant-condition": ["error", { "checkLoops": false }],
+        "no-empty-function": "off",
         "no-eval": "error",
         "no-eq-null": "error",
-        "no-alert": "warn",
-        "max-classes-per-file": ["error", 1],
-        "no-implicit-coercion": "error",
-        "no-extend-native": "error",
-        "no-lonely-if": "error",
-        "@typescript-eslint/no-unused-vars": "error",
         "no-throw-literal": "error",
         "no-unused-expressions": "error",
         "no-useless-call": "error",
-        "prefer-promise-reject-errors": ["error", {"allowEmptyReject": true}],
-        "require-await": "error",
-        "prefer-const": "warn"
+        "no-implicit-coercion": "error",
+        "no-extend-native": "error",
+        "no-lonely-if": "error",
+
+        "@typescript-eslint/no-non-null-assertion": "off",
+        "@typescript-eslint/no-inferrable-types": "off",
+        "@typescript-eslint/no-empty-function": "warn",
+        "@typescript-eslint/no-unused-vars": "error",
+
+        "max-classes-per-file": ["error", 1],
+        
+        "prefer-promise-reject-errors": ["error", { "allowEmptyReject": true }],
+        "prefer-const": "warn",
+
+        "require-await": "error"
+        
     },
     "env": {
         "browser": true

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "ringofsnakes-client",
-    "version": "0.7.0",
+    "version": "0.8.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "ringofsnakes-client",
-            "version": "0.7.0",
+            "version": "0.8.0",
             "dependencies": {
                 "comlink": "^4.3.1",
                 "preact": "^10.10.6"

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ringofsnakes-client",
-    "version": "0.7.0",
+    "version": "0.8.0",
     "description": "",
     "repository": {
         "type": "git",

--- a/client/src/app/data/Game.ts
+++ b/client/src/app/data/Game.ts
@@ -30,6 +30,7 @@ export default class Game {
     private _config: GameConfig;
     private updateAvailable: boolean = false;
     private targetSnakeId: number | undefined;
+    private _targetSnakeKills: number = 0;
     private stopped: boolean = false;
 
     private readonly events = {
@@ -128,8 +129,12 @@ export default class Game {
         this.snakeChunks.addMultiple(changes.snakeChunks);
 
         // remove dead snakes
-        for (const snakeId of changes.snakeDeaths) {
-            const snake = this.snakes.get(snakeId);
+        for (const { deadSnakeId, killerSnakeId } of changes.snakeDeaths) {
+            const snake = this.snakes.get(deadSnakeId);
+
+            if (killerSnakeId === this.targetSnakeId) {
+                this._targetSnakeKills++;
+            }
 
             if (!snake) {
                 continue;
@@ -141,9 +146,9 @@ export default class Game {
                 this.snakeChunks.remove(snakeChunk.id);
             }
 
-            this.snakes.remove(snakeId);
+            this.snakes.remove(deadSnakeId);
 
-            if (snakeId === this.targetSnakeId) {
+            if (deadSnakeId === this.targetSnakeId) {
                 this.targetSnakeId = undefined;
             }
 
@@ -198,6 +203,10 @@ export default class Game {
         }
 
         return this.snakes.get(this.targetSnakeId);
+    }
+
+    get targetSnakeKills(): number {
+        return this._targetSnakeKills;
     }
 
     private removeJunk() {

--- a/client/src/app/data/Game.ts
+++ b/client/src/app/data/Game.ts
@@ -98,9 +98,9 @@ export default class Game {
         return [game, player];
     }
 
-    // eslint-disable-next-line require-await
     static async joinAsSpectator(): Promise<Game> {
-        throw new Error("not implemented");
+        await Promise.reject(new Error("not implemented"));
+        return new Game(); // TODO
     }
 
     /**

--- a/client/src/app/data/Player.ts
+++ b/client/src/app/data/Player.ts
@@ -26,8 +26,8 @@ export default class Player {
 
         UserInput.addListener(this.inputListener);
 
-        game.addEventListener("snakeDeath", (snake) => {
-            if (snake.id !== this.snakeId) {
+        game.events.snakeDeath.addListener(({ deadSnakeId }) => {
+            if (deadSnakeId !== this.snakeId) {
                 return;
             }
 

--- a/client/src/app/data/dto/DataUpdateDTO.ts
+++ b/client/src/app/data/dto/DataUpdateDTO.ts
@@ -1,6 +1,7 @@
 import { FoodChunkDTO } from "./FoodChunkDTO";
 import { GameStatisticsDTO } from "./GameStatisticsDTO";
 import { SnakeChunkDTO } from "./SnakeChunkDTO";
+import { SnakeDeathDTO } from "./SnakeDeathDTO";
 import { SnakeDTO } from "./SnakeDTO";
 
 export type DataUpdateDTO = {
@@ -9,11 +10,9 @@ export type DataUpdateDTO = {
 
     snakes: SnakeDTO[];
     snakeChunks: SnakeChunkDTO[];
-    snakeDeaths: SnakeId[];
+    snakeDeaths: SnakeDeathDTO[];
     foodChunks: FoodChunkDTO[];
 
     leaderboard?: GameStatisticsDTO;
     heatMap?: Uint8Array;
 };
-
-type SnakeId = number;

--- a/client/src/app/data/dto/GameStatisticsDTO.ts
+++ b/client/src/app/data/dto/GameStatisticsDTO.ts
@@ -7,5 +7,6 @@ export type GameStatisticsDTO = {
 export type LeaderboardEntry = {
     id: number;
     name: string;
-    score: number;
+    length: number;
+    kills: number;
 };

--- a/client/src/app/data/dto/SnakeDeathDTO.ts
+++ b/client/src/app/data/dto/SnakeDeathDTO.ts
@@ -1,6 +1,9 @@
 export type SnakeDeathDTO = {
     deadSnakeId: SnakeId;
-    killerSnakeId?: SnakeId;
+    killer?: {
+        snakeId: SnakeId;
+        name: string;
+    };
 };
 
 type SnakeId = number;

--- a/client/src/app/data/dto/SnakeDeathDTO.ts
+++ b/client/src/app/data/dto/SnakeDeathDTO.ts
@@ -1,0 +1,6 @@
+export type SnakeDeathDTO = {
+    deadSnakeId: SnakeId;
+    killerSnakeId?: SnakeId;
+};
+
+type SnakeId = number;

--- a/client/src/app/ui/GameOverlay.tsx
+++ b/client/src/app/ui/GameOverlay.tsx
@@ -28,7 +28,7 @@ export default class GameOverlay extends Component<Props> {
             <>
                 <GameStatistics data={game.leaderboard} />
                 <FPSStats />
-                <SnakeInfoUI snake={game.targetSnake} kills={game.targetSnakeKills}/>
+                <SnakeInfoUI snake={game.targetSnake} kills={game.targetSnakeKills} />
             </>
         );
     }

--- a/client/src/app/ui/GameOverlay.tsx
+++ b/client/src/app/ui/GameOverlay.tsx
@@ -28,7 +28,7 @@ export default class GameOverlay extends Component<Props> {
             <>
                 <GameStatistics data={game.leaderboard} />
                 <FPSStats />
-                <SnakeInfoUI snake={game.targetSnake} />
+                <SnakeInfoUI snake={game.targetSnake} kills={game.targetSnakeKills}/>
             </>
         );
     }

--- a/client/src/app/ui/components/GameStatistics.tsx
+++ b/client/src/app/ui/components/GameStatistics.tsx
@@ -41,7 +41,10 @@ function LeaderboardEntry(props: Readonly<Props>) {
 
     return (
         <div class="entry">
-            {index + 1}. {entry.name}: {entry.score}
+            <span>{index + 1}.</span>
+            <span>{entry.name}</span>
+            <span title="length">{entry.length}</span>
+            <span title="kills">{entry.kills === 0 ? "-" : entry.kills + "K"}</span>
         </div>
     );
 }

--- a/client/src/app/ui/components/SnakeInfoUI.tsx
+++ b/client/src/app/ui/components/SnakeInfoUI.tsx
@@ -3,6 +3,7 @@ import Snake from "../../data/snake/Snake";
 
 type Props = {
     snake?: Readonly<Snake>;
+    kills?: number;
 };
 
 export default class SnakeInfoUI extends Component<Props> {
@@ -13,12 +14,20 @@ export default class SnakeInfoUI extends Component<Props> {
             return null;
         }
 
+        const kills = this.props.kills ?? 0;
+
         return (
             <div id="snake-info">
                 <div id="snake-name">{snake.name}</div>
-                <div id="snake-length">
+                <div id="snake-data">
                     <span class="label">Length:</span>
                     <span class="value">{Math.round(snake.length)}</span>
+                    {kills > 0 ? (
+                        <>
+                            <span class="label">Kills:</span>
+                            <span class="value">{kills}</span>
+                        </>
+                    ) : null}
                 </div>
             </div>
         );

--- a/client/src/app/worker/data/GameDataBuffer.ts
+++ b/client/src/app/worker/data/GameDataBuffer.ts
@@ -81,11 +81,16 @@ export default class GameDataBuffer {
     addJSONUpdate(update: ServerToClientJSONMessage): void {
         switch (update.tag) {
             case "SnakeDeathInfo": {
-                console.info(`Snake ${update.snakeId} has died.`);
+                console.info(`Snake ${update.deadSnakeId} has died.`);
                 this.addInformation({
-                    snakeDeaths: [update.snakeId]
+                    snakeDeaths: [
+                        {
+                            deadSnakeId: update.deadSnakeId,
+                            killerSnakeId: update.killerSnakeId
+                        }
+                    ]
                 });
-                this.snakeNames.delete(update.snakeId);
+                this.snakeNames.delete(update.deadSnakeId);
                 this.triggerUpdateEvent();
                 break;
             }

--- a/client/src/app/worker/data/GameDataBuffer.ts
+++ b/client/src/app/worker/data/GameDataBuffer.ts
@@ -88,7 +88,13 @@ export default class GameDataBuffer {
                     snakeDeaths: [
                         {
                             deadSnakeId: update.deadSnakeId,
-                            killerSnakeId: update.killerSnakeId
+                            killer:
+                                update.killerSnakeId !== undefined
+                                    ? {
+                                          snakeId: update.killerSnakeId,
+                                          name: this.getSnakeName(update.killerSnakeId)
+                                      }
+                                    : undefined
                         }
                     ]
                 });
@@ -160,6 +166,10 @@ export default class GameDataBuffer {
         }
 
         this.serverUpdateEventTrigger();
+    }
+
+    private getSnakeName(snakeId: SnakeId): string {
+        return this.snakeNames.get(snakeId) ?? `Snake ${snakeId}`;
     }
 }
 

--- a/client/src/app/worker/data/GameDataBuffer.ts
+++ b/client/src/app/worker/data/GameDataBuffer.ts
@@ -81,7 +81,9 @@ export default class GameDataBuffer {
     addJSONUpdate(update: ServerToClientJSONMessage): void {
         switch (update.tag) {
             case "SnakeDeathInfo": {
-                console.info(`Snake ${update.deadSnakeId} has died.`);
+                if (!__TEST__) {
+                    console.info(`Snake ${update.deadSnakeId} has died.`);
+                }
                 this.addInformation({
                     snakeDeaths: [
                         {

--- a/client/src/app/worker/data/JSONMessages.ts
+++ b/client/src/app/worker/data/JSONMessages.ts
@@ -17,7 +17,8 @@ export type SpawnInfo = Readonly<{
 
 export type SnakeDeathInfo = Readonly<{
     tag: "SnakeDeathInfo";
-    snakeId: number;
+    deadSnakeId: number;
+    killerSnakeId?: number;
 }>;
 
 export type LeaderboardData = Readonly<

--- a/client/src/styles/game-statistics.less
+++ b/client/src/styles/game-statistics.less
@@ -28,6 +28,7 @@
     display: grid;
     grid-template-columns: max-content 1fr max-content max-content;
     gap: 0;
+    align-items: end;
 
     border-bottom: 1px solid rgb(128,128,128);
     margin-bottom: 4px;
@@ -36,6 +37,7 @@
     .entry {
         display: flex;
         flex-direction: row;
+        align-items: baseline;
         padding: 3px;
         font-family: monospace;
         text-align: right;

--- a/client/src/styles/game-statistics.less
+++ b/client/src/styles/game-statistics.less
@@ -25,6 +25,9 @@
 }
 
 #leaderboard {
+    display: grid;
+    grid-template-columns: max-content 1fr max-content max-content;
+
     border-bottom: 1px solid rgb(128,128,128);
     margin-bottom: 4px;
     padding-bottom: 4px;
@@ -33,9 +36,23 @@
         display: flex;
         flex-direction: row;
         padding: 3px;
-        font-weight: bold;
-        font-size: 12px;
         font-family: monospace;
+        text-align: right;
+        gap: 0.5em;
+
+        > span {
+            font-size: 0.9em;
+        }
+
+        > span:nth-child(2) {
+            text-align: left;
+            font-size: 1em;
+            font-weight: bold;
+        }
+
+        > span:nth-child(1), > span:nth-child(4) {
+            color: rgb(200,200,200);
+        }
     }
 }
 

--- a/client/src/styles/game-statistics.less
+++ b/client/src/styles/game-statistics.less
@@ -27,6 +27,7 @@
 #leaderboard {
     display: grid;
     grid-template-columns: max-content 1fr max-content max-content;
+    gap: 0;
 
     border-bottom: 1px solid rgb(128,128,128);
     margin-bottom: 4px;

--- a/client/src/styles/snake-info.less
+++ b/client/src/styles/snake-info.less
@@ -3,22 +3,34 @@
     left: 10px;
     bottom: 10px;
     padding: 5px;
-    min-width: 100px;
+    min-width: 90px;
 
     background-color: rgb(64, 64, 64);
     color: white;
-    font-size: 12px;
+    font-size: 14px;
 
     animation: snake-info-in 0.3s ease-out;
 
-    #snake-length {
-        .label {
-            margin-right: 6px;
+    #snake-data {
+        display: grid;
+        grid-template-columns: max-content max-content;
+        gap: 0px 6px;
+        align-items: start;
+        
+        > span {
+            line-height: 14px;
         }
+
+        .label {
+            font-size: 12px;
+            color: rgb(200,200,200);
+        }
+
         .value {
             font-weight: bold;
             font-size: 14px;
             font-family: monospace;
+            text-align: right;
         }
     }
 

--- a/client/src/styles/snake-info.less
+++ b/client/src/styles/snake-info.less
@@ -15,7 +15,7 @@
         display: grid;
         grid-template-columns: max-content max-content;
         gap: 0px 6px;
-        align-items: start;
+        align-items: baseline;
         
         > span {
             line-height: 14px;

--- a/client/test/worker/data/GameDataBuffer.test.ts
+++ b/client/test/worker/data/GameDataBuffer.test.ts
@@ -27,7 +27,7 @@ describe("GameDataBuffer", () => {
 
         buffer.addJSONUpdate({
             tag: "SnakeDeathInfo",
-            snakeId: spawnInfo.snakeId
+            deadSnakeId: spawnInfo.snakeId
         });
 
         let lastUpdate = buffer.nextUpdate();
@@ -66,7 +66,7 @@ describe("GameDataBuffer", () => {
 
         buffer.addJSONUpdate({
             tag: "SnakeDeathInfo",
-            snakeId: 13
+            deadSnakeId: 13
         });
 
         expect(eventCallback).toHaveBeenCalledTimes(1);

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.kielergames</groupId>
     <artifactId>ringofsnakes-server</artifactId>
-    <version>0.8.2</version>
+    <version>0.9.0</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/server/src/main/java/game/Game.java
+++ b/server/src/main/java/game/Game.java
@@ -86,7 +86,7 @@ public class Game {
             }
 
             otherSnake.addKill();
-            final var killMessage = gson.toJson(new SnakeDeathInfo(snake));
+            final var killMessage = gson.toJson(new SnakeDeathInfo(snake, otherSnake));
             executor.schedule(() -> clients.forEach((sId, client) -> client.send(killMessage)), 0, TimeUnit.MILLISECONDS);
         }
     }

--- a/server/src/main/java/game/Game.java
+++ b/server/src/main/java/game/Game.java
@@ -80,11 +80,14 @@ public class Game {
             System.out.println(snake + " collided with " + otherSnake + ".");
             snake.kill();
 
-            if (!snake.isAlive()) {
-                // some snakes, such as the BoundarySnake are not killable
-                final var killMessage = gson.toJson(new SnakeDeathInfo(snake));
-                executor.schedule(() -> clients.forEach((sId, client) -> client.send(killMessage)), 0, TimeUnit.MILLISECONDS);
+            if (snake.isAlive()) {
+                // Some snakes, such as the BoundarySnake are not killable.
+                return;
             }
+
+            otherSnake.addKill();
+            final var killMessage = gson.toJson(new SnakeDeathInfo(snake));
+            executor.schedule(() -> clients.forEach((sId, client) -> client.send(killMessage)), 0, TimeUnit.MILLISECONDS);
         }
     }
 

--- a/server/src/main/java/game/snake/Snake.java
+++ b/server/src/main/java/game/snake/Snake.java
@@ -6,9 +6,9 @@ import game.world.World;
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.Setter;
+import math.Direction;
 import math.Vector;
 import util.BitWithShortHistory;
-import math.Direction;
 
 import java.nio.ByteBuffer;
 import java.util.Comparator;
@@ -45,6 +45,7 @@ public class Snake {
     private double lengthBuffer = 0;
     @Getter private double width;
     private double foodTrailBuffer = 0f;
+    @Getter private int kills = 0;
 
     Snake(char id, World world) {
         this(id, world, "Snake " + ((int) id));
@@ -243,6 +244,15 @@ public class Snake {
     public void kill() {
         recycleSnake();
         alive = false;
+    }
+
+    public void addKill() {
+        if (kills == Integer.MAX_VALUE) {
+            // Avoid integer overflow. Very unlikely to ever happen to
+            // a normal snake but this could happen to the BoundarySnake.
+            return;
+        }
+        kills++;
     }
 
     public Vector getTailPosition() {

--- a/server/src/main/java/server/protocol/GameStatistics.java
+++ b/server/src/main/java/server/protocol/GameStatistics.java
@@ -29,12 +29,14 @@ public class GameStatistics extends ServerToClientJSONMessage {
     private static class LeaderboardEntry {
         final int id;
         final String name;
-        final int score;
+        final int length;
+        final int kills;
 
         private LeaderboardEntry(Snake snake) {
-            this.name = snake.name;
-            this.score = (int) snake.getLength();
-            this.id = snake.id;
+            name = snake.name;
+            length = (int) snake.getLength();
+            id = snake.id;
+            kills = snake.getKills();
         }
     }
 }

--- a/server/src/main/java/server/protocol/SnakeDeathInfo.java
+++ b/server/src/main/java/server/protocol/SnakeDeathInfo.java
@@ -3,9 +3,11 @@ package server.protocol;
 import game.snake.Snake;
 
 public class SnakeDeathInfo extends ServerToClientJSONMessage {
-    public final int snakeId;
+    final int deadSnakeId;
+    final Integer killerSnakeId;
 
-    public SnakeDeathInfo(Snake snake) {
-        snakeId = snake.id;
+    public SnakeDeathInfo(Snake snake, Snake killer) {
+        deadSnakeId = snake.id;
+        killerSnakeId = (killer == null) ? null : ((int) killer.id);
     }
 }


### PR DESCRIPTION
Added a kill counter to the `Snake` class. When snake A crashed into snake B the kill counter of snake B will be increased. The kills will be displayed in the leader board:

![image](https://user-images.githubusercontent.com/10491533/186018749-06a4439d-088e-4049-b5b7-ec6e32c233c9.png) 
The Snake `SneakyReptile` has length 57 and 4 kills.

Also refactored some code and added a Game Over dialog with a try again button:
![image](https://user-images.githubusercontent.com/10491533/186018896-64ec9adc-900d-4160-aa81-a1449f1dc25b.png)

Closes #224 