### PR TITLE
Visual indicator for fast snakes

### DIFF
--- a/client/src/app/renderer/modules/SnakeChunkRenderer.ts
+++ b/client/src/app/renderer/modules/SnakeChunkRenderer.ts
@@ -41,6 +41,7 @@ export function render(game: Readonly<Game>, transform: ReadonlyMatrix): void {
 
         // Set the snake specific uniforms once.
         SkinLoader.setColor(shader, "uSkin", snake.skin);
+        shader.setUniform("uSnakeFast", snake.fast ? 1.0 : 0.0);
         shader.setUniform("uSnakeLength", snake.length);
         shader.setUniform("uSnakeMaxWidth", snake.width);
         shader.setUniform(

--- a/client/src/app/renderer/modules/SnakeChunkRenderer.ts
+++ b/client/src/app/renderer/modules/SnakeChunkRenderer.ts
@@ -41,7 +41,7 @@ export function render(game: Readonly<Game>, transform: ReadonlyMatrix): void {
 
         // Set the snake specific uniforms once.
         SkinLoader.setColor(shader, "uSkin", snake.skin);
-        shader.setUniform("uSnakeFast", snake.fast ? 1.0 : 0.0);
+        shader.setUniform("uSnakeFast", snake.smoothedFastValue);
         shader.setUniform("uSnakeLength", snake.length);
         shader.setUniform("uSnakeMaxWidth", snake.width);
         shader.setUniform(

--- a/client/src/app/renderer/modules/SnakeHeadRenderer.ts
+++ b/client/src/app/renderer/modules/SnakeHeadRenderer.ts
@@ -48,6 +48,7 @@ export function render(game: Readonly<Game>, transform: ReadonlyMatrix): void {
         shader.setUniform("uSnakeWidth", 1.25 * snake.width);
         shader.setUniform("uHeadPosition", [x, y]);
         shader.setUniform("uHeadRotation", snake.direction + rotOffset);
+        shader.setUniform("uSnakeFast", snake.fast ? 1.0 : 0.0);
         SkinManager.setColor(shader, "uSkin", snake.skin);
 
         shader.run(vertexData.length / VERTEX_SIZE, {

--- a/client/src/app/renderer/modules/SnakeHeadRenderer.ts
+++ b/client/src/app/renderer/modules/SnakeHeadRenderer.ts
@@ -48,7 +48,7 @@ export function render(game: Readonly<Game>, transform: ReadonlyMatrix): void {
         shader.setUniform("uSnakeWidth", 1.25 * snake.width);
         shader.setUniform("uHeadPosition", [x, y]);
         shader.setUniform("uHeadRotation", snake.direction + rotOffset);
-        shader.setUniform("uSnakeFast", snake.fast ? 1.0 : 0.0);
+        shader.setUniform("uSnakeFast", snake.smoothedFastValue);
         SkinManager.setColor(shader, "uSkin", snake.skin);
 
         shader.run(vertexData.length / VERTEX_SIZE, {

--- a/client/src/shader/head.frag
+++ b/client/src/shader/head.frag
@@ -4,7 +4,7 @@ uniform sampler2D uColorSampler;
 uniform lowp float uSkin;
 uniform lowp float uSnakeFast;
 
-const vec4 fastColorBoost = vec4(0.15, 0.15, 0.15, 0.0);
+const vec4 fastColorBoost = vec4(0.175, 0.175, 0.175, 0.0);
 
 void main(void) {
 	vec4 skinColor = texture2D(uColorSampler, vec2(uSkin, 0.25));

--- a/client/src/shader/head.frag
+++ b/client/src/shader/head.frag
@@ -2,7 +2,11 @@ precision mediump float;
 
 uniform sampler2D uColorSampler;
 uniform lowp float uSkin;
+uniform lowp float uSnakeFast;
+
+const vec4 fastColorBoost = vec4(0.15, 0.15, 0.15, 0.0);
 
 void main(void) {
-	gl_FragColor = texture2D(uColorSampler, vec2(uSkin, 0.25));
+	vec4 skinColor = texture2D(uColorSampler, vec2(uSkin, 0.25));
+	gl_FragColor = skinColor + uSnakeFast * fastColorBoost;
 }

--- a/client/src/shader/snake.frag
+++ b/client/src/shader/snake.frag
@@ -9,7 +9,7 @@ varying float vPathOffset;
 varying float vNormalOffset;
 
 const vec3 darkGrey = vec3(0.1, 0.1, 0.1);
-const vec3 fastColorBoost = vec3(0.15, 0.15, 0.15);
+const vec3 fastColorBoost = vec3(0.175, 0.175, 0.175);
 
 void main(void) {
 	vec3 skinColor = texture2D(uColorSampler, vec2(uSkin, 0.25)).rgb;

--- a/client/src/shader/snake.frag
+++ b/client/src/shader/snake.frag
@@ -3,11 +3,13 @@ precision mediump float;
 uniform sampler2D uColorSampler;
 uniform lowp float uSkin;
 uniform highp float uSnakeLength;
+uniform lowp float uSnakeFast;
 
 varying float vPathOffset;
 varying float vNormalOffset;
 
 const vec3 darkGrey = vec3(0.1, 0.1, 0.1);
+const vec3 fastColorBoost = vec3(0.15, 0.15, 0.15);
 
 void main(void) {
 	vec3 skinColor = texture2D(uColorSampler, vec2(uSkin, 0.25)).rgb;
@@ -17,7 +19,7 @@ void main(void) {
 	co = co * co;
 	co = co * (1.0 + 0.25*sin(2.0*vPathOffset));
 
-	vec3 color = mix(skinColor, darkColor, co);
+	vec3 color = mix(skinColor + uSnakeFast * fastColorBoost, darkColor, co);
 
 	gl_FragColor = vec4(color, vPathOffset < uSnakeLength ? 1.0 : 0.0);
 }

--- a/server/src/main/java/game/GameConfig.java
+++ b/server/src/main/java/game/GameConfig.java
@@ -48,7 +48,7 @@ public final class GameConfig {
 
         public SnakeInfo(double speed) {
             this.speed = speed;
-            fastSpeed = 2.0 * speed;
+            fastSpeed = 2.5 * speed;
         }
     }
 }


### PR DESCRIPTION
Fast snakes now have a slightly different (brighter) color:

![Screenshot](https://user-images.githubusercontent.com/10491533/186527758-d0fd3554-3a8f-4f17-a2b5-a45366550c4e.png)

Also increased the default fast speed from `2x` normal speed to `2.5x`.