### PR TITLE
Use ES2022 private fields

### DIFF
--- a/client/.eslintrc.json
+++ b/client/.eslintrc.json
@@ -22,6 +22,7 @@
         "@typescript-eslint/no-inferrable-types": "off",
         "@typescript-eslint/no-empty-function": "warn",
         "@typescript-eslint/no-unused-vars": "error",
+        "@typescript-eslint/prefer-as-const": "error",
 
         "max-classes-per-file": ["error", 1],
         

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "ringofsnakes-client",
-    "version": "0.9.0",
+    "version": "0.9.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "ringofsnakes-client",
-            "version": "0.9.0",
+            "version": "0.9.1",
             "dependencies": {
                 "comlink": "^4.3.1",
                 "preact": "^10.10.6"

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ringofsnakes-client",
-    "version": "0.9.0",
+    "version": "0.9.1",
     "description": "",
     "repository": {
         "type": "git",

--- a/client/src/app/data/Game.ts
+++ b/client/src/app/data/Game.ts
@@ -143,9 +143,6 @@ export default class Game {
         this.foodChunks.addMultiple(changes.foodChunks);
 
         this.snakes.addMultiple(changes.snakes, ticks);
-        if (this.#targetSnakeId !== undefined) {
-            this.snakes.runIfPresent(this.#targetSnakeId, (snake) => (snake.target = true));
-        }
 
         // update snake chunks AFTER snakes
         this.snakeChunks.addMultiple(changes.snakeChunks);

--- a/client/src/app/data/Player.ts
+++ b/client/src/app/data/Player.ts
@@ -7,36 +7,36 @@ import * as UserInput from "../input/UserInput";
 type Remote = Comlink.Remote<WorkerAPI>;
 
 export default class Player {
-    private remote: Remote;
-    private game: Game;
     readonly snakeId: number;
-    private _alive: boolean = true;
-    private inputListener: UserInputListener;
+    #remote: Remote;
+    #game: Game;
+    #alive: boolean = true;
+    #inputListener: UserInputListener;
 
     constructor(remote: Remote, snakeId: number, game: Game) {
-        this.remote = remote;
         this.snakeId = snakeId;
-        this.game = game;
+        this.#remote = remote;
+        this.#game = game;
 
-        this.inputListener = (wantsFast, direction) => {
+        this.#inputListener = (wantsFast, direction) => {
             if (this.alive) {
-                this.remote.sendUserInput(direction, wantsFast, this.game.camera.viewBox);
+                this.#remote.sendUserInput(direction, wantsFast, this.#game.camera.viewBox);
             }
         };
 
-        UserInput.addListener(this.inputListener);
+        UserInput.addListener(this.#inputListener);
 
         game.events.snakeDeath.addListener(({ deadSnakeId }) => {
             if (deadSnakeId !== this.snakeId) {
                 return;
             }
 
-            this._alive = false;
-            UserInput.removeListener(this.inputListener);
+            this.#alive = false;
+            UserInput.removeListener(this.#inputListener);
         });
     }
 
     get alive(): boolean {
-        return this._alive;
+        return this.#alive;
     }
 }

--- a/client/src/app/data/camera/Camera.ts
+++ b/client/src/app/data/camera/Camera.ts
@@ -9,15 +9,15 @@ SCALE_MATRIX.setEntry(0, 0, WORLD_SCALE);
 SCALE_MATRIX.setEntry(1, 1, WORLD_SCALE);
 
 export default class Camera {
-    private _position: Vector = new Vector(0, 0);
+    #position: Vector = new Vector(0, 0);
 
-    private _unstretch: Matrix = new Matrix(true);
-    private _translation: Matrix = new Matrix(true);
+    #unstretch: Matrix = new Matrix(true);
+    #translation: Matrix = new Matrix(true);
 
-    private _lastTransformMatrix: ReadonlyMatrix | null = null;
+    #lastTransformMatrix: ReadonlyMatrix | null = null;
 
     setRatio(width: number, height: number): void {
-        this._unstretch.setEntry(0, 0, height / width);
+        this.#unstretch.setEntry(0, 0, height / width);
     }
 
     moveToSnake(snake: Snake): void {
@@ -25,8 +25,8 @@ export default class Camera {
     }
 
     moveTo(position: Vector): void {
-        this._position.set(position);
-        this._lastTransformMatrix = null;
+        this.#position.set(position);
+        this.#lastTransformMatrix = null;
         // TODO
     }
 
@@ -50,27 +50,27 @@ export default class Camera {
     }
 
     get position(): Vector {
-        return this._position;
+        return this.#position;
     }
 
     get transformMatrix(): ReadonlyMatrix {
-        if (this._lastTransformMatrix === null) {
-            const pos = this._position;
-            this._translation.setEntry(0, 2, -pos.x);
-            this._translation.setEntry(1, 2, -pos.y);
+        if (this.#lastTransformMatrix === null) {
+            const pos = this.#position;
+            this.#translation.setEntry(0, 2, -pos.x);
+            this.#translation.setEntry(1, 2, -pos.y);
 
-            this._lastTransformMatrix = Matrix.compose(
-                Matrix.compose(this._unstretch, SCALE_MATRIX),
-                this._translation
+            this.#lastTransformMatrix = Matrix.compose(
+                Matrix.compose(this.#unstretch, SCALE_MATRIX),
+                this.#translation
             );
         }
 
-        return this._lastTransformMatrix;
+        return this.#lastTransformMatrix;
     }
 
     get viewBox(): Rectangle {
-        const center = this._position;
-        const ratio = this._unstretch.getEntry(0, 0);
+        const center = this.#position;
+        const ratio = this.#unstretch.getEntry(0, 0);
 
         // the WebGL viewbox has width & height 2: [-1,1] x [-1,1]
         const width = 2.0 / (ratio * WORLD_SCALE);

--- a/client/src/app/data/world/FoodChunk.ts
+++ b/client/src/app/data/world/FoodChunk.ts
@@ -21,36 +21,37 @@ const boxCoords = [
 export default class FoodChunk implements ManagedObject<number, FoodChunkDTO> {
     static readonly FOOD_VERTEX_SIZE = 2 + 2 + 1; // x,y, u,v, c
 
-    id: number;
-    private gpuBuffer: WebGLBuffer;
-    private gpuData: Float32Array | undefined = new Float32Array(32 * boxCoords.length);
-    private numFoodItems: number;
-    private lastUpdateTime: number;
+    readonly id: number;
     readonly box: Rectangle;
+
+    #gpuBuffer: WebGLBuffer;
+    #gpuData: Float32Array | undefined = new Float32Array(32 * boxCoords.length);
+    #numFoodItems: number;
+    #lastUpdateTime: number;
 
     constructor(dto: FoodChunkDTO) {
         this.id = dto.id;
         this.box = Rectangle.fromTransferable(dto.bounds);
-        this.gpuBuffer = BufferManager.create();
+        this.#gpuBuffer = BufferManager.create();
         this.update(dto);
     }
 
     update(dto: FoodChunkDTO): void {
-        this.numFoodItems = dto.items.length;
-        this.gpuData = createGPUData(dto.items, this.gpuData);
-        this.lastUpdateTime = FrameTime.now();
+        this.#numFoodItems = dto.items.length;
+        this.#gpuData = createGPUData(dto.items, this.#gpuData);
+        this.#lastUpdateTime = FrameTime.now();
     }
 
     destroy(): void {
-        BufferManager.free(this.gpuBuffer);
+        BufferManager.free(this.#gpuBuffer);
     }
 
     useBuffer(gl: WebGLRenderingContext): void {
-        gl.bindBuffer(gl.ARRAY_BUFFER, this.gpuBuffer);
+        gl.bindBuffer(gl.ARRAY_BUFFER, this.#gpuBuffer);
 
-        if (this.gpuData) {
-            gl.bufferData(gl.ARRAY_BUFFER, this.gpuData, gl.STATIC_DRAW);
-            this.gpuData = undefined;
+        if (this.#gpuData) {
+            gl.bufferData(gl.ARRAY_BUFFER, this.#gpuData, gl.STATIC_DRAW);
+            this.#gpuData = undefined;
         }
     }
 
@@ -59,14 +60,14 @@ export default class FoodChunk implements ManagedObject<number, FoodChunkDTO> {
     }
 
     get numberOfVertices(): number {
-        return this.numFoodItems * boxCoords.length;
+        return this.#numFoodItems * boxCoords.length;
     }
 
     /**
      * Time since this chunk was created or last updated.
      */
     get age(): number {
-        return 0.001 * (FrameTime.now() - this.lastUpdateTime);
+        return 0.001 * (FrameTime.now() - this.#lastUpdateTime);
     }
 }
 

--- a/client/src/app/main.tsx
+++ b/client/src/app/main.tsx
@@ -16,13 +16,13 @@ import "../styles/main.less";
 // initialize main canvas
 const canvas = document.createElement("canvas");
 canvas.id = "mainCanvas";
-document.body.appendChild(canvas);
+document.body.append(canvas);
 WebGLContextProvider.init(canvas);
 
 // text layer
 const textLayer = document.createElement("div");
 textLayer.id = "textLayer";
-document.body.appendChild(textLayer);
+document.body.append(textLayer);
 TextRenderer.init(textLayer);
 
 InputDirectionDisplay.appendTo(document.body);
@@ -30,7 +30,7 @@ InputDirectionDisplay.appendTo(document.body);
 // initialize UI container
 const uiRoot = document.createElement("div");
 uiRoot.id = "root";
-document.body.appendChild(uiRoot);
+document.body.append(uiRoot);
 UserInput.init(uiRoot);
 
 initDialogs();

--- a/client/src/app/renderer/modules/SnakeNameRenderer.ts
+++ b/client/src/app/renderer/modules/SnakeNameRenderer.ts
@@ -9,9 +9,14 @@ const snakeNameSize = 12;
 
 export function render(game: Readonly<Game>): void {
     const canvas = WebGLContextProvider.getContext().canvas;
+    const targetSnake = game.targetSnake;
 
     for (const snake of game.snakes.values()) {
-        if (snake.target || !snake.hasChunks() || !isVisible(game.camera, snake.position)) {
+        if (
+            snake === targetSnake ||
+            !snake.hasChunks() ||
+            !isVisible(game.camera, snake.position)
+        ) {
             continue;
         }
 

--- a/client/src/app/ui/Dialogs.ts
+++ b/client/src/app/ui/Dialogs.ts
@@ -29,7 +29,7 @@ export function dialog(options: DialogOptions): Promise<string> {
 
 export function init(): void {
     dialogLayer.id = "dialogLayer";
-    document.body.appendChild(dialogLayer);
+    document.body.append(dialogLayer);
 }
 
 function showNextDialog() {

--- a/client/src/app/ui/GameOverlay.tsx
+++ b/client/src/app/ui/GameOverlay.tsx
@@ -9,16 +9,16 @@ type Props = {
 };
 
 export default class GameOverlay extends Component<Props> {
-    private timer: number;
+    #timer: number;
 
     componentDidMount() {
-        this.timer = window.setInterval(() => {
+        this.#timer = window.setInterval(() => {
             this.forceUpdate();
         }, 500);
     }
 
     componentWillUnmount() {
-        window.clearInterval(this.timer);
+        window.clearInterval(this.#timer);
     }
 
     render() {

--- a/client/src/app/ui/InputDirectionDisplay.ts
+++ b/client/src/app/ui/InputDirectionDisplay.ts
@@ -5,12 +5,12 @@ const ring = document.createElement("div");
 const marker = document.createElement("div");
 
 export function appendTo(parent: HTMLElement): void {
-    parent.appendChild(container);
+    parent.append(container);
 }
 
 (function init() {
-    ring.appendChild(marker);
-    container.appendChild(ring);
+    ring.append(marker);
+    container.append(ring);
 
     container.id = "input-container";
     ring.id = "input-viz-ring";

--- a/client/src/app/ui/components/debug/FPSStats.tsx
+++ b/client/src/app/ui/components/debug/FPSStats.tsx
@@ -12,76 +12,76 @@ type State = {
 };
 
 export default class FPSStats extends Component<Props, State> {
-    private canvasRef = createRef<HTMLCanvasElement>();
-    private ctx: CanvasRenderingContext2D;
-    private rafHandle: number;
-    private frameCountCanvas = 0;
-    private frameCountText = 0;
-    private lastCanvasUpdate: number;
-    private lastTextUpdate: number;
-    private maxFPS: number;
+    #canvasRef = createRef<HTMLCanvasElement>();
+    #ctx: CanvasRenderingContext2D;
+    #rafHandle: number;
+    #frameCountCanvas = 0;
+    #frameCountText = 0;
+    #lastCanvasUpdate: number;
+    #lastTextUpdate: number;
+    #maxFPS: number;
 
-    public constructor(props: Props) {
+    constructor(props: Props) {
         super(props);
-        this.maxFPS = props.maxFPS ?? 60;
+        this.#maxFPS = props.maxFPS ?? 60;
     }
 
-    public componentDidMount() {
+    componentDidMount() {
         // init
-        const ctx = this.canvasRef.current!.getContext("2d", { alpha: false })!;
-        this.ctx = ctx;
-        this.lastCanvasUpdate = performance.now();
-        this.lastTextUpdate = this.lastCanvasUpdate;
+        const ctx = this.#canvasRef.current!.getContext("2d", { alpha: false })!;
+        this.#ctx = ctx;
+        this.#lastCanvasUpdate = performance.now();
+        this.#lastTextUpdate = this.#lastCanvasUpdate;
 
         // background
         ctx.fillStyle = "black";
         ctx.fillRect(0, 0, ctx.canvas.width, ctx.canvas.height);
 
         // start frame counting
-        this.rafHandle = window.requestAnimationFrame(this.beforeFrame.bind(this));
+        this.#rafHandle = window.requestAnimationFrame(this.#beforeFrame.bind(this));
     }
 
-    private beforeFrame() {
+    #beforeFrame() {
         const now = performance.now();
-        const canvasDelta = now - this.lastCanvasUpdate;
-        const textDelta = now - this.lastTextUpdate;
+        const canvasDelta = now - this.#lastCanvasUpdate;
+        const textDelta = now - this.#lastTextUpdate;
         const canvasUpdateInterval = 1000 / canvasUpdateFrequency;
 
         if (canvasDelta >= canvasUpdateInterval) {
-            this.updateCanvas();
-            this.lastCanvasUpdate = now - (canvasDelta - canvasUpdateInterval);
-            this.frameCountCanvas = 0;
+            this.#updateCanvas();
+            this.#lastCanvasUpdate = now - (canvasDelta - canvasUpdateInterval);
+            this.#frameCountCanvas = 0;
         }
 
         if (textDelta >= 1000) {
-            const fps = this.frameCountText;
-            this.frameCountText = 0;
-            this.lastTextUpdate = now - (textDelta - 1000);
+            const fps = this.#frameCountText;
+            this.#frameCountText = 0;
+            this.#lastTextUpdate = now - (textDelta - 1000);
             this.setState({ fps });
         }
 
-        this.frameCountCanvas++;
-        this.frameCountText++;
+        this.#frameCountCanvas++;
+        this.#frameCountText++;
 
-        this.rafHandle = window.requestAnimationFrame(this.beforeFrame.bind(this));
+        this.#rafHandle = window.requestAnimationFrame(this.#beforeFrame.bind(this));
     }
 
-    private updateCanvas() {
-        const ctx = this.ctx;
+    #updateCanvas() {
+        const ctx = this.#ctx;
         const canvas = ctx.canvas;
 
-        const fps = this.frameCountCanvas * canvasUpdateFrequency;
+        const fps = this.#frameCountCanvas * canvasUpdateFrequency;
 
-        if (fps > this.maxFPS) {
+        if (fps > this.#maxFPS) {
             // update scale
-            const height = Math.round((canvas.height * this.maxFPS) / fps);
+            const height = Math.round((canvas.height * this.#maxFPS) / fps);
             ctx.drawImage(canvas, 0, canvas.height - height, canvas.width, height);
 
             // draw background
             ctx.fillStyle = "black";
             ctx.fillRect(0, 0, canvas.width, canvas.height - height);
 
-            this.maxFPS = fps;
+            this.#maxFPS = fps;
         }
 
         // shift left
@@ -105,19 +105,19 @@ export default class FPSStats extends Component<Props, State> {
         // add new bar
         ctx.fillStyle = "black";
         ctx.fillRect(canvas.width - barWidth, canvas.height, barWidth, canvas.height);
-        const h = Math.floor((canvas.height * fps) / this.maxFPS);
+        const h = Math.floor((canvas.height * fps) / this.#maxFPS);
         ctx.fillStyle = "white";
         ctx.fillRect(canvas.width - barWidth, canvas.height - h, barWidth, h);
     }
 
-    public componentWillUnmount() {
-        window.cancelAnimationFrame(this.rafHandle);
+    componentWillUnmount() {
+        window.cancelAnimationFrame(this.#rafHandle);
     }
 
-    public render() {
+    render() {
         return (
             <div id="fps-stats">
-                <canvas ref={this.canvasRef} width={100} height={42} />
+                <canvas ref={this.#canvasRef} width={100} height={42} />
                 <div id="fps-text">{`FPS: ${this.state.fps ?? "-"}`}</div>
             </div>
         );

--- a/client/src/app/util/AppEvent.ts
+++ b/client/src/app/util/AppEvent.ts
@@ -1,13 +1,13 @@
 import { Consumer } from "./FunctionTypes";
 
 export class AppEvent<T = void> {
-    private readonly listeners = new Set<Consumer<T>>();
+    readonly #listeners = new Set<Consumer<T>>();
 
     addListener(listener: Consumer<T>): void {
-        this.listeners.add(listener);
+        this.#listeners.add(listener);
     }
 
     trigger(data: T): void {
-        this.listeners.forEach((listener) => listener(data));
+        this.#listeners.forEach((listener) => listener(data));
     }
 }

--- a/client/src/app/util/AsyncEvent.ts
+++ b/client/src/app/util/AsyncEvent.ts
@@ -1,27 +1,27 @@
 type PromiseResolver = () => void;
 
 export default class AsyncEvent {
-    private flag: boolean = false;
-    private promise: Promise<void> | undefined = undefined;
-    private resolver: PromiseResolver | undefined = undefined;
+    #flag: boolean = false;
+    #promise: Promise<void> | undefined = undefined;
+    #resolver: PromiseResolver | undefined = undefined;
 
     set(): void {
-        this.flag = true;
+        this.#flag = true;
 
-        if (this.resolver) {
-            const resolve = this.resolver;
-            this.resolver = undefined;
-            this.promise = undefined;
+        if (this.#resolver) {
+            const resolve = this.#resolver;
+            this.#resolver = undefined;
+            this.#promise = undefined;
             resolve();
         }
     }
 
     clear(): void {
-        this.flag = false;
+        this.#flag = false;
     }
 
     isSet(): boolean {
-        return this.flag;
+        return this.#flag;
     }
 
     /**
@@ -29,23 +29,23 @@ export default class AsyncEvent {
      * @param timeout Timeout in ms. Values <= 0 are ignored.
      */
     wait(timeout: number = 0): Promise<void> {
-        if (this.flag) {
+        if (this.#flag) {
             return Promise.resolve();
         }
 
-        if (this.promise === undefined) {
-            this.promise = new Promise((resolve) => (this.resolver = resolve));
+        if (this.#promise === undefined) {
+            this.#promise = new Promise((resolve) => (this.#resolver = resolve));
         }
 
         if (timeout > 0) {
             return Promise.race([
-                this.promise,
+                this.#promise,
                 new Promise<void>((_, reject) => {
                     window.setTimeout(reject, timeout);
                 })
             ]);
         }
 
-        return this.promise;
+        return this.#promise;
     }
 }

--- a/client/src/app/util/ManagedMap.ts
+++ b/client/src/app/util/ManagedMap.ts
@@ -11,25 +11,25 @@ type WithId<T> = { id: T };
 type Factory<T, DTO> = (dto: DTO) => T;
 
 export class ManagedMap<DTO extends WithId<K>, K, V extends ManagedObject<K, DTO, CI>, CI = void> {
-    private readonly data: Map<K, V> = new Map();
-    private readonly factory: Factory<V, DTO>;
+    readonly #data: Map<K, V> = new Map();
+    readonly #factory: Factory<V, DTO>;
 
     /**
      * @param factory A function to create values given a data transfer object.
      */
     constructor(factory: Factory<V, DTO>) {
-        this.factory = factory;
+        this.#factory = factory;
     }
 
     add(dto: DTO, info: CI): void {
-        const storedValue = this.data.get(dto.id);
+        const storedValue = this.#data.get(dto.id);
 
         if (storedValue) {
             storedValue.update(dto, info);
         } else {
-            const value = this.factory(dto);
+            const value = this.#factory(dto);
             assert(dto.id === value.id);
-            this.data.set(dto.id, value);
+            this.#data.set(dto.id, value);
         }
     }
 
@@ -40,15 +40,15 @@ export class ManagedMap<DTO extends WithId<K>, K, V extends ManagedObject<K, DTO
     }
 
     get(id: K): V | undefined {
-        return this.data.get(id);
+        return this.#data.get(id);
     }
 
     has(id: K): boolean {
-        return this.data.has(id);
+        return this.#data.has(id);
     }
 
     runIfPresent(id: K, consumer: Consumer<V>): boolean {
-        const value = this.data.get(id);
+        const value = this.#data.get(id);
         if (value) {
             consumer(value);
         }
@@ -61,10 +61,10 @@ export class ManagedMap<DTO extends WithId<K>, K, V extends ManagedObject<K, DTO
      * @returns The removed element or undefined if it does not exist.
      */
     remove(id: K): V | undefined {
-        const value = this.data.get(id);
+        const value = this.#data.get(id);
 
         if (value) {
-            this.data.delete(id);
+            this.#data.delete(id);
 
             if (value.destroy) {
                 value.destroy();
@@ -82,7 +82,7 @@ export class ManagedMap<DTO extends WithId<K>, K, V extends ManagedObject<K, DTO
     removeIf(isJunk: Predicate<V>): V[] {
         // collect junk
         const removeList: V[] = [];
-        for (const obj of this.data.values()) {
+        for (const obj of this.#data.values()) {
             if (isJunk(obj)) {
                 removeList.push(obj);
             }
@@ -93,29 +93,29 @@ export class ManagedMap<DTO extends WithId<K>, K, V extends ManagedObject<K, DTO
             if (obj.destroy) {
                 obj.destroy();
             }
-            this.data.delete(obj.id);
+            this.#data.delete(obj.id);
         }
 
         return removeList;
     }
 
     forEach(consumer: BiConsumer<V, K>): void {
-        this.data.forEach(consumer);
+        this.#data.forEach(consumer);
     }
 
     values(): IterableIterator<V> {
-        return this.data.values();
+        return this.#data.values();
     }
 
     entries(): IterableIterator<[K, V]> {
-        return this.data.entries();
+        return this.#data.entries();
     }
 
     clear(): void {
-        this.data.clear();
+        this.#data.clear();
     }
 
     get size(): number {
-        return this.data.size;
+        return this.#data.size;
     }
 }

--- a/client/src/app/util/RateLimiter.ts
+++ b/client/src/app/util/RateLimiter.ts
@@ -4,11 +4,11 @@ import { Consumer } from "./FunctionTypes";
 type TimeoutId = number;
 
 export default class RateLimiter<T> {
-    private minDelay: number;
-    private lastRealUpdate: number = performance.now();
-    private nextValue: T | null = null;
-    private timeout: TimeoutId | undefined = undefined;
-    private updateConsumer: Consumer<T>;
+    #minDelay: number;
+    #lastRealUpdate: number = performance.now();
+    #nextValue: T | null = null;
+    #timeout: TimeoutId | undefined = undefined;
+    #updateConsumer: Consumer<T>;
 
     /**
      * Limits the rate at which an update consumer is called.
@@ -17,41 +17,41 @@ export default class RateLimiter<T> {
      */
     constructor(minDelay: number, updateConsumer: Consumer<T>) {
         assert(minDelay > 0);
-        this.minDelay = minDelay;
-        this.updateConsumer = updateConsumer;
+        this.#minDelay = minDelay;
+        this.#updateConsumer = updateConsumer;
     }
 
     setValue(newValue: T): void {
-        if (this.timeout !== undefined) {
-            this.nextValue = newValue;
+        if (this.#timeout !== undefined) {
+            this.#nextValue = newValue;
             return;
         }
 
         const now = performance.now();
-        const delay = now - this.lastRealUpdate;
+        const delay = now - this.#lastRealUpdate;
 
-        if (delay >= this.minDelay) {
-            this.lastRealUpdate = now;
-            this.updateConsumer(newValue);
+        if (delay >= this.#minDelay) {
+            this.#lastRealUpdate = now;
+            this.#updateConsumer(newValue);
             return;
         }
 
-        const scheduleDelay = this.minDelay - delay;
+        const scheduleDelay = this.#minDelay - delay;
 
-        this.timeout = setTimeout(() => {
-            this.timeout = undefined;
+        this.#timeout = setTimeout(() => {
+            this.#timeout = undefined;
 
-            if (this.nextValue !== null) {
-                this.updateConsumer(this.nextValue);
-                this.nextValue = null;
+            if (this.#nextValue !== null) {
+                this.#updateConsumer(this.#nextValue);
+                this.#nextValue = null;
             }
         }, scheduleDelay) as unknown as TimeoutId;
     }
 
     abort(): void {
-        if (this.timeout !== undefined) {
-            clearTimeout(this.timeout);
-            this.timeout = undefined;
+        if (this.#timeout !== undefined) {
+            clearTimeout(this.#timeout);
+            this.#timeout = undefined;
         }
     }
 }

--- a/client/src/app/worker/encoder/SnakeChunkVertexBufferBuilder.ts
+++ b/client/src/app/worker/encoder/SnakeChunkVertexBufferBuilder.ts
@@ -5,28 +5,29 @@ export const VERTEX_SIZE = 6;
 export default class SnakeChunkVertexBufferBuilder {
     readonly vertices: number;
     readonly buffer: Float32Array;
-    private readonly pathPoints: number;
-    private readonly chunkPathLength: number;
-    private position: number = 0;
+
+    readonly #pathPoints: number;
+    readonly #chunkPathLength: number;
+    #position: number = 0;
 
     constructor(numPoints: number, chunkLength: number) {
         assert(numPoints > 0);
         assert(chunkLength > 0.0);
 
-        this.pathPoints = numPoints;
-        this.vertices = 2 * this.pathPoints; // triangle strip format
-        this.chunkPathLength = chunkLength;
+        this.#pathPoints = numPoints;
+        this.vertices = 2 * this.#pathPoints; // triangle strip format
+        this.#chunkPathLength = chunkLength;
 
         this.buffer = new Float32Array(this.vertices * VERTEX_SIZE);
     }
 
     addPoint(x: number, y: number, alpha: number, pathOffset: number): void {
-        this.checkCanAdd();
+        this.#checkCanAdd();
         const vb = this.buffer;
 
         // current position in vertex buffer
-        let pos = this.position;
-        this.position += 2 * VERTEX_SIZE;
+        let pos = this.#position;
+        this.#position += 2 * VERTEX_SIZE;
 
         // compute normal vector
         const normalAlpha = alpha - 0.5 * Math.PI;
@@ -34,7 +35,7 @@ export default class SnakeChunkVertexBufferBuilder {
         const ny = Math.sin(normalAlpha);
 
         // path distance to chunk end (end point closest to snake head)
-        const pathDist = this.chunkPathLength - pathOffset;
+        const pathDist = this.#chunkPathLength - pathOffset;
 
         // right vertex
         vb[pos + 0] = x;
@@ -56,15 +57,15 @@ export default class SnakeChunkVertexBufferBuilder {
     }
 
     duplicateLastPoint(): void {
-        this.checkCanAdd();
+        this.#checkCanAdd();
 
         // current position in vertex buffer
-        const pos = this.position;
+        const pos = this.#position;
         const vbo = pos - 2 * VERTEX_SIZE;
         if (vbo < 0) {
             throw new Error("No point to duplicate.");
         }
-        this.position += 2 * VERTEX_SIZE;
+        this.#position += 2 * VERTEX_SIZE;
 
         const vb = this.buffer;
 
@@ -74,8 +75,8 @@ export default class SnakeChunkVertexBufferBuilder {
         }
     }
 
-    private checkCanAdd() {
-        if (this.position >= this.buffer.length) {
+    #checkCanAdd() {
+        if (this.#position >= this.buffer.length) {
             throw new RangeError("Cannot add another point to vertex buffer.");
         }
     }

--- a/client/src/app/worker/socket.ts
+++ b/client/src/app/worker/socket.ts
@@ -15,19 +15,20 @@ export interface Socket {
 const noop = () => {};
 
 class SocketImpl implements Socket {
-    private websocket: WebSocket;
+    #websocket: WebSocket;
     onclose = noop;
     onJSONMessage: Consumer<ServerToClientJSONMessage> = noop;
     onBinaryMessage: Consumer<ArrayBuffer> = noop;
+    
     constructor(websocket: WebSocket) {
-        this.websocket = websocket;
-        this.websocket.onclose = (e: CloseEvent) => {
+        this.#websocket = websocket;
+        this.#websocket.onclose = (e: CloseEvent) => {
             const { code, reason, wasClean } = e;
             console.info("WebSocket closed", code, reason, wasClean);
             this.onclose();
         };
-        this.websocket.onerror = () => console.error("WebSocket error");
-        this.websocket.onmessage = (e: MessageEvent<string | ArrayBuffer>) => {
+        this.#websocket.onerror = () => console.error("WebSocket error");
+        this.#websocket.onmessage = (e: MessageEvent<string | ArrayBuffer>) => {
             const data = e.data;
 
             if (data instanceof ArrayBuffer) {
@@ -40,21 +41,21 @@ class SocketImpl implements Socket {
     }
 
     sendJSON(message: ClientToServerJSONMessage) {
-        this.websocket.send(JSON.stringify(message));
+        this.#websocket.send(JSON.stringify(message));
     }
 
     sendBinary(message: ArrayBuffer) {
-        this.websocket.send(message);
+        this.#websocket.send(message);
     }
 
     close() {
-        if (this.websocket.readyState !== WebSocket.CLOSED) {
-            this.websocket.close();
+        if (this.#websocket.readyState !== WebSocket.CLOSED) {
+            this.#websocket.close();
         }
     }
 
     isOpen() {
-        return this.websocket.readyState === WebSocket.OPEN;
+        return this.#websocket.readyState === WebSocket.OPEN;
     }
 }
 

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -1,9 +1,9 @@
 {
     "compilerOptions": {
         "outDir": "./public",
-        "target": "es2020",
-        "module": "es2020",
-        "lib": ["dom", "es2020"],
+        "target": "es2022",
+        "module": "es2022",
+        "lib": ["dom", "es2022"],
         "moduleResolution": "node",
         "sourceMap": true,
         "jsx": "react-jsx",


### PR DESCRIPTION
This PR changes private fields in classes from TypeScript `private` to actual private fields (`#`). This results in a 5% size reduction of the JS bundle (main + worker). Contains no functional changes.