### PR TITLE
Use SL4J and JUL for logging

### DIFF
--- a/server/.gitignore
+++ b/server/.gitignore
@@ -1,3 +1,4 @@
 target
 .classpath
 snake-server-*.jar
+*.log

--- a/server/SERVER_SETUP.md
+++ b/server/SERVER_SETUP.md
@@ -8,6 +8,7 @@
  - create user `ci`: `sudo useradd -m ci`
  - add public key to `.ssh/authorized_keys`
  - copy restart script `scp restart.sh ci@<server>:/home/ci`
+ - configure logging (enable FileHandler in `logging.properties`)
 
 The last three steps are only required for our CI pipeline.
 

--- a/server/logging.properties
+++ b/server/logging.properties
@@ -1,6 +1,8 @@
 handlers = java.util.logging.ConsoleHandler
 #handlers = java.util.logging.ConsoleHandler, java.util.logging.FileHandler
 
+# Logging levels: SEVERE, WARNING, INFO, CONFIG, FINE, FINER, FINEST
+
 java.util.logging.FileHandler.level     = CONFIG
 java.util.logging.FileHandler.encoding  = UTF-8
 java.util.logging.FileHandler.append    = false
@@ -8,5 +10,8 @@ java.util.logging.FileHandler.pattern   = server.%u.%g.log
 java.util.logging.FileHandler.formatter = java.util.logging.SimpleFormatter
 java.util.logging.FileHandler.count     = 4
 
-java.util.logging.ConsoleHandler.level    = WARNING
+java.util.logging.ConsoleHandler.level    = INFO
 java.util.logging.ConsoleHandler.encoding = UTF-8
+
+# Avoid console spam when developing:
+org.eclipse.jetty.level = WARNING

--- a/server/logging.properties
+++ b/server/logging.properties
@@ -1,0 +1,12 @@
+handlers = java.util.logging.ConsoleHandler
+#handlers = java.util.logging.ConsoleHandler, java.util.logging.FileHandler
+
+java.util.logging.FileHandler.level     = CONFIG
+java.util.logging.FileHandler.encoding  = UTF-8
+java.util.logging.FileHandler.append    = false
+java.util.logging.FileHandler.pattern   = server.%u.%g.log
+java.util.logging.FileHandler.formatter = java.util.logging.SimpleFormatter
+java.util.logging.FileHandler.count     = 4
+
+java.util.logging.ConsoleHandler.level    = WARNING
+java.util.logging.ConsoleHandler.encoding = UTF-8

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -17,6 +17,7 @@
         <jetty.version>9.4.49.v20220914</jetty.version>
         <mockito.version>4.8.1</mockito.version>
         <junit.version>5.9.1</junit.version>
+        <slf4j.version>2.0.3</slf4j.version>
     </properties>
 
     <dependencies>
@@ -71,8 +72,13 @@
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-simple</artifactId>
-            <version>2.0.3</version>
+            <artifactId>slf4j-api</artifactId>
+            <version>${slf4j.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-jdk14</artifactId>
+            <version>${slf4j.version}</version>
         </dependency>
         <dependency>
             <groupId>org.projectlombok</groupId>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.kielergames</groupId>
     <artifactId>ringofsnakes-server</artifactId>
-    <version>0.10.2</version>
+    <version>0.11.0</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -127,7 +127,7 @@
                             <transformers>
                                 <transformer
                                         implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-                                    <mainClass>server.SnakeServer</mainClass>
+                                    <mainClass>Main</mainClass>
                                 </transformer>
                             </transformers>
                             <artifactSet>

--- a/server/src/main/java/Main.java
+++ b/server/src/main/java/Main.java
@@ -1,0 +1,7 @@
+import server.SnakeServer;
+
+public class Main {
+    public static void main(String[] args) throws InterruptedException {
+        SnakeServer.start();
+    }
+}

--- a/server/src/main/java/Main.java
+++ b/server/src/main/java/Main.java
@@ -1,7 +1,32 @@
 import server.SnakeServer;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.logging.LogManager;
+
 public class Main {
     public static void main(String[] args) throws InterruptedException {
+        initializeLogging();
         SnakeServer.start();
+    }
+
+    private static void initializeLogging() {
+        if (System.getProperties().contains("java.util.logging.config.file")) {
+            return;
+        }
+
+        final var manager = LogManager.getLogManager();
+        final var path = Paths.get("logging.properties").toAbsolutePath();
+
+        if (Files.exists(path)) {
+            System.out.println("Using logging config file: " + path);
+            System.setProperty("java.util.logging.config.file", path.toString());
+            try {
+                manager.readConfiguration();
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
     }
 }

--- a/server/src/main/java/debugview/DebugView.java
+++ b/server/src/main/java/debugview/DebugView.java
@@ -28,7 +28,7 @@ public class DebugView extends Application {
 
         // start game server
         new Thread(() -> {
-            SnakeServer.startServerWithGame(game);
+            SnakeServer.start(game);
             game.start();
         }).start();
 

--- a/server/src/main/java/game/snake/BoundarySnake.java
+++ b/server/src/main/java/game/snake/BoundarySnake.java
@@ -4,10 +4,13 @@ import game.world.World;
 import math.BoundingBox;
 import math.Direction;
 import math.Vector;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.concurrent.ThreadLocalRandom;
 
 public class BoundarySnake extends Snake {
+    private static final Logger LOGGER = LoggerFactory.getLogger(BoundarySnake.class);
     private final BoundingBox bottom, right, up, left;
 
     BoundarySnake(char id, World world) {
@@ -95,7 +98,7 @@ public class BoundarySnake extends Snake {
 
     @Override
     public void kill() {
-        System.err.println("Boundary snake can not be killed.");
+        LOGGER.warn("Boundary snake can not be killed.");
     }
 
     @Override

--- a/server/src/main/java/game/snake/Snake.java
+++ b/server/src/main/java/game/snake/Snake.java
@@ -6,6 +6,8 @@ import game.world.World;
 import lombok.Getter;
 import math.Direction;
 import math.Vector;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import util.BitWithShortHistory;
 
 import java.nio.ByteBuffer;
@@ -20,7 +22,7 @@ public class Snake {
     public static final int INFO_BYTE_SIZE = 26;
     public static final int NUMBER_OF_SKINS = 7;
     public static final double LENGTH_FOR_95_PERCENT_OF_MAX_WIDTH = 1024.0;
-
+    private static final Logger LOGGER = LoggerFactory.getLogger(Snake.class);
     public final GameConfig config;
     public final char id;
     public final String name;
@@ -71,7 +73,7 @@ public class Snake {
 
     public void setTargetDirection(double alpha) {
         if (Math.abs(alpha) > Math.PI + 1e-4) {
-            System.err.println("Alpha out of range: " + alpha);
+            LOGGER.warn("Alpha out of range: {}", alpha);
             return;
         }
 

--- a/server/src/main/java/server/SnakeServer.java
+++ b/server/src/main/java/server/SnakeServer.java
@@ -6,6 +6,8 @@ import org.eclipse.jetty.server.*;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.eclipse.jetty.websocket.jsr356.server.deploy.WebSocketServerContainerInitializer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import server.clients.Client;
 import server.clients.Player;
 
@@ -18,7 +20,8 @@ import java.util.Map;
 import java.util.concurrent.ExecutionException;
 
 public class SnakeServer {
-    private final static Map<String, Client> clients = Collections.synchronizedMap(new HashMap<>(64));
+    private static final Logger LOGGER = LoggerFactory.getLogger(SnakeServer.class);
+    private static final Map<String, Client> CLIENTS = Collections.synchronizedMap(new HashMap<>(64));
     private static Game game;
 
     public static Server start(Game game) {
@@ -62,7 +65,7 @@ public class SnakeServer {
     }
 
     public static void onNewClientConnected(Session session) {
-        System.out.println("A new client has connected.");
+        LOGGER.info("A new client has connected.");
         Player player;
         try {
             player = game.createPlayer(session).get();
@@ -71,24 +74,24 @@ public class SnakeServer {
             return;
         }
 
-        clients.put(session.getId(), player);
+        CLIENTS.put(session.getId(), player);
     }
 
     public static void removeClient(Session session) {
         final var sessionId = session.getId();
-        clients.remove(sessionId);
+        CLIENTS.remove(sessionId);
         game.removeClient(session);
-        System.out.println("Client has been removed. (" + sessionId + ")");
+        LOGGER.info("Client has been removed. (" + sessionId + ")");
     }
 
     public static void updateClient(Client newClient) {
         final var sessionId = newClient.session.getId();
-        final var oldClient = clients.put(sessionId, newClient);
+        final var oldClient = CLIENTS.put(sessionId, newClient);
         assert oldClient != null;
     }
 
     public static void handleClientMessage(Session session, float alpha, boolean fast, float ratio) {
-        final var client = clients.get(session.getId());
+        final var client = CLIENTS.get(session.getId());
         client.setViewBoxRatio(ratio);
         client.handleUserInput(alpha, fast);
     }
@@ -97,12 +100,12 @@ public class SnakeServer {
         final var env = System.getenv();
 
         if (!env.containsKey("SNAKE_KEYSTORE_PATH") || !env.containsKey("SNAKE_KEYSTORE_PW")) {
-            System.err.println("Cannot create a secure connector without keystore configuration.");
+            LOGGER.warn("Cannot create a secure connector without keystore configuration.");
             return;
         }
 
         if (!Files.exists(Paths.get(env.get("SNAKE_KEYSTORE_PATH")))) {
-            System.err.println("Keystore file not found, skipping secure connector.");
+            LOGGER.warn("Keystore file not found, skipping secure connector.");
             return;
         }
 
@@ -119,5 +122,6 @@ public class SnakeServer {
         final ServerConnector wssConnector = new ServerConnector(server, sslConnectionFactory, httpConnectionFactory);
         wssConnector.setPort(8443);
         server.addConnector(wssConnector);
+        LOGGER.debug("Secure Websockets enabled.");
     }
 }

--- a/server/src/main/java/server/SnakeServer.java
+++ b/server/src/main/java/server/SnakeServer.java
@@ -33,17 +33,12 @@ public class SnakeServer {
         addSecureConnector(server);
 
         // Set up the basic application "context" for this application at "/"
-        // This is also known as the handler tree (in jetty speak)
         ServletContextHandler context = new ServletContextHandler(ServletContextHandler.SESSIONS);
         context.setContextPath("/");
         server.setHandler(context);
 
         WebSocketServerContainerInitializer.configure(context, (servletContext, wsContainer) -> {
-            // This lambda will be called at the appropriate place in the
-            // ServletContext initialization phase where you can initialize
-            // and configure  your websocket container.
-
-            // Configure defaults for container
+            // TODO #155: Find optimal websocket config
             wsContainer.setDefaultMaxTextMessageBufferSize(65535);
 
             // Add WebSocket endpoint to javax.websocket layer

--- a/server/src/main/java/server/SnakeServer.java
+++ b/server/src/main/java/server/SnakeServer.java
@@ -21,7 +21,7 @@ public class SnakeServer {
     private final static Map<String, Client> clients = Collections.synchronizedMap(new HashMap<>(64));
     private static Game game;
 
-    public static Server startServerWithGame(Game game) {
+    public static Server start(Game game) {
         SnakeServer.game = game;
 
         Server server = new Server();
@@ -59,9 +59,9 @@ public class SnakeServer {
         return server;
     }
 
-    public static void main(String[] args) throws InterruptedException {
+    public static void start() throws InterruptedException {
         game = new Game();
-        final var server = startServerWithGame(game);
+        final var server = start(game);
         game.start();
         server.join();
     }

--- a/server/src/main/java/server/clients/Spectator.java
+++ b/server/src/main/java/server/clients/Spectator.java
@@ -3,6 +3,8 @@ package server.clients;
 import game.snake.Snake;
 import math.BoundingBox;
 import math.Vector;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import server.protocol.SpectatorChange;
 import util.JSON;
 
@@ -11,6 +13,7 @@ import javax.websocket.CloseReason;
 import java.io.IOException;
 
 public class Spectator extends Client {
+    private static final Logger LOGGER = LoggerFactory.getLogger(Spectator.class);
     private static final CloseReason ILLEGAL_INPUT = new CloseReason(CloseReason.CloseCodes.VIOLATED_POLICY, "User input not allowed as spectator.");
     private Vector position;
 
@@ -65,12 +68,12 @@ public class Spectator extends Client {
             return;
         }
 
-        System.err.println("Illegal request from client.");
+        LOGGER.error("Illegal request from client.");
         try {
             session.close(ILLEGAL_INPUT);
             // TODO: does this cause removeClient to be called?
         } catch (IOException e) {
-            System.err.println(e.getMessage());
+            LOGGER.error(e.getMessage());
         }
     }
 }

--- a/server/src/main/resources/simplelogger.properties
+++ b/server/src/main/resources/simplelogger.properties
@@ -1,1 +1,0 @@
-org.slf4j.simpleLogger.defaultLogLevel=warn


### PR DESCRIPTION
Instead of logging using `System.out.println` and `System.err.println` we now use `java.util.logging` and the SL4J API for logging. This allows us to save logs as files and define custom log levels (see `logging.properties`).

Closes #50 