### PR TITLE
Efficient snake recycling

### DIFF
--- a/server/pom.xml
+++ b/server/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.kielergames</groupId>
     <artifactId>ringofsnakes-server</artifactId>
-    <version>0.11.0</version>
+    <version>0.11.1</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/server/src/main/java/debugview/DebugView.java
+++ b/server/src/main/java/debugview/DebugView.java
@@ -54,7 +54,7 @@ public class DebugView extends Application {
                 game.awaitExecution(() -> {
                     ctx.clearRect(0, 0, 800, 600);
 
-                    if (!game.snakes.isEmpty()) {
+                    if (!game.getSnakes().isEmpty()) {
                         final var playerId = game.streamClients()
                                 .filter(Player.class::isInstance)
                                 .map(Player.class::cast)
@@ -87,7 +87,7 @@ public class DebugView extends Application {
     }
 
     private void drawSnakes(GraphicsContext g, OptionalInt playerId) {
-        game.snakes.forEach(snake -> {
+        game.getSnakes().forEach(snake -> {
             g.setFill(Color.BLACK);
             g.setStroke(Color.BLACK);
             if (playerId.isPresent() && snake.id == playerId.getAsInt()) {
@@ -129,8 +129,8 @@ public class DebugView extends Application {
 
 
     private void drawCurrentWorldChunk(GraphicsContext g) {
-        if (game != null && game.snakes.size() != 0) {
-            var snake = game.snakes.get(0);
+        if (game != null && game.getSnakes().size() != 0) {
+            var snake = game.getSnakes().get(0);
             var x = game.world.chunks.findChunk(snake.getHeadPosition()).box.getCenter().x;
             var y = game.world.chunks.findChunk(snake.getHeadPosition()).box.getCenter().y;
             var height = game.world.chunks.findChunk(snake.getHeadPosition()).box.getHeight();

--- a/server/src/main/java/debugview/DebugView.java
+++ b/server/src/main/java/debugview/DebugView.java
@@ -79,7 +79,7 @@ public class DebugView extends Application {
         g.setFill(Color.RED);
         g.setStroke(Color.RED);
         game.world.chunks.forEach(chunk -> chunk.streamFood().forEach(food -> {
-            var size = food.size.value;
+            var size = food.size.radius;
             g.fillOval((food.position.x - camera.x) * ZOOM + 400 - size * ZOOM,
                     300 - (food.position.y - camera.y) * ZOOM - size * ZOOM,
                     size * ZOOM, size * ZOOM);

--- a/server/src/main/java/game/Game.java
+++ b/server/src/main/java/game/Game.java
@@ -272,9 +272,9 @@ public class Game {
             }
 
             final var foodAmount = collectedFood.stream()
-                    .mapToDouble(food -> food.size.nutritionalValue)
-                    .sum();
-            // TODO: we have nutritionalValue twice, one should suffice
+                    .mapToDouble(food -> food.size.area)
+                    .sum() / Math.PI;
+
             snake.grow(foodAmount * config.foodNutritionalValue / snake.getWidth());
             worldChunk.removeFood(collectedFood);
         });

--- a/server/src/main/java/game/Game.java
+++ b/server/src/main/java/game/Game.java
@@ -261,6 +261,7 @@ public class Game {
             final var foodCollectRadius = snake.getWidth() * 1.1 + 1.0;
             final var headPosition = snake.getHeadPosition();
             final var worldChunk = world.chunks.findChunk(headPosition);
+            // TODO: consider neighboring chunks if distance is less than foodCollectRadius
 
             final var collectedFood = worldChunk.streamFood()
                     .filter(food -> food.isWithinRange(headPosition, foodCollectRadius))
@@ -273,6 +274,7 @@ public class Game {
             final var foodAmount = collectedFood.stream()
                     .mapToDouble(food -> food.size.nutritionalValue)
                     .sum();
+            // TODO: we have nutritionalValue twice, one should suffice
             snake.grow(foodAmount * config.foodNutritionalValue / snake.getWidth());
             worldChunk.removeFood(collectedFood);
         });

--- a/server/src/main/java/game/Game.java
+++ b/server/src/main/java/game/Game.java
@@ -275,11 +275,11 @@ public class Game {
                 }
 
                 final var foodAmount = collectedFood.stream()
-                        .mapToDouble(food -> food.size.area)
-                        .sum() / Math.PI;
+                        .mapToDouble(food -> food.size.nutritionalValue(config))
+                        .sum();
 
                 // Consume food.
-                snake.grow(foodAmount * config.foodNutritionalValue / snake.getWidth());
+                snake.grow(foodAmount / snake.getWidth());
                 chunk.removeFood(collectedFood);
             });
         });

--- a/server/src/main/java/game/Game.java
+++ b/server/src/main/java/game/Game.java
@@ -277,6 +277,7 @@ public class Game {
             // Consume food.
             snake.grow(foodAmount * config.foodNutritionalValue / snake.getWidth());
             worldChunk.removeFood(collectedFood);
+            // TODO: remove food from neighboring chunks
         });
     }
 

--- a/server/src/main/java/game/Game.java
+++ b/server/src/main/java/game/Game.java
@@ -38,8 +38,9 @@ public class Game {
     public final GameConfig config;
     public final World world;
     public final CollisionManager collisionManager;
-    public final List<Snake> snakes = new LinkedList<>();
+    protected final List<Snake> snakes = new LinkedList<>();
     protected final ExceptionalExecutorService executor;
+    private final List<Snake> unmodifiableViewOfSnakes = Collections.unmodifiableList(snakes);
     private final Map<Session, Client> clientsBySession = Collections.synchronizedMap(new HashMap<>(64));
     private final Multimap<Snake, Client> clientsBySnake = Multimaps.synchronizedMultimap(HashMultimap.create(64, 4));
     private final List<Bot> bots = new LinkedList<>();
@@ -63,6 +64,10 @@ public class Game {
         });
         collisionManager = new CollisionManager(this);
         collisionManager.onCollisionDo(this::onCollision);
+    }
+
+    public List<Snake> getSnakes() {
+        return unmodifiableViewOfSnakes;
     }
 
     private void onCollision(Snake snake, Collidable object) {

--- a/server/src/main/java/game/Game.java
+++ b/server/src/main/java/game/Game.java
@@ -258,7 +258,7 @@ public class Game {
 
     private void eatFood() {
         forEachSnake(snake -> {
-            final var foodCollectRadius = snake.getWidth() * 1.1 + 1.0;
+            final var foodCollectRadius = snake.getWidth() * 1.1 + 0.32;
             final var headPosition = snake.getHeadPosition();
             final var worldChunk = world.chunks.findChunk(headPosition);
             // TODO: consider neighboring chunks if distance is less than foodCollectRadius

--- a/server/src/main/java/game/Game.java
+++ b/server/src/main/java/game/Game.java
@@ -47,17 +47,10 @@ public class Game {
     private byte ticksSinceLastUpdate = 0;
 
     public Game() {
-        this(new GameConfig());
+        this(new World(new GameConfig(), true));
 
         final var boundarySnake = SnakeFactory.createBoundarySnake(world);
         snakes.add(boundarySnake);
-    }
-
-    /**
-     * For tests only.
-     */
-    protected Game(GameConfig config) {
-        this(new World(config));
     }
 
     protected Game(World world) {

--- a/server/src/main/java/game/snake/FinalSnakeChunk.java
+++ b/server/src/main/java/game/snake/FinalSnakeChunk.java
@@ -2,6 +2,7 @@ package game.snake;
 
 import lombok.Getter;
 import math.BoundingBox;
+import math.Vector;
 
 import java.nio.ByteBuffer;
 import java.util.List;
@@ -14,7 +15,8 @@ public class FinalSnakeChunk extends SnakeChunk {
     @Getter private final int uniqueId;
     private final BoundingBox boundingBox;
     final private List<SnakePathPoint> pathData;
-    private double snakeOffset = 0.0;
+    private double offsetInSnake = 0.0;
+    private SnakeChunk.PointQueryInfo lastQueryInfo;
 
     protected FinalSnakeChunk(
             Snake snake,
@@ -59,11 +61,11 @@ public class FinalSnakeChunk extends SnakeChunk {
 
     @Override
     public double getOffset() {
-        return snakeOffset;
+        return offsetInSnake;
     }
 
     public void setOffset(double offset) {
-        this.snakeOffset = offset;
+        this.offsetInSnake = offset;
         chunkByteBuffer.putFloat(BUFFER_OFFSET_POS, (float) offset);
     }
 
@@ -74,5 +76,23 @@ public class FinalSnakeChunk extends SnakeChunk {
     @Override
     public int hashCode() {
         return this.getUniqueId();
+    }
+
+    @Override
+    public Vector getPositionAt(double inSnakeOffset) {
+        var pathData = getPathData();
+
+        if (lastQueryInfo != null && inSnakeOffset >= lastQueryInfo.offset) {
+            // Performance optimization: Since points in pathData are ordered by offset
+            // we can skip the ones before the last queried point and thereby avoid O(n²)
+            // runtime in World#recycleDeadSnake.
+            pathData = pathData.subList(lastQueryInfo.index, pathData.size());
+        }
+
+        if (lastQueryInfo == null) {
+            lastQueryInfo = new SnakeChunk.PointQueryInfo();
+        }
+
+        return getPositionAt(inSnakeOffset, pathData, lastQueryInfo);
     }
 }

--- a/server/src/main/java/game/snake/FinalSnakeChunk.java
+++ b/server/src/main/java/game/snake/FinalSnakeChunk.java
@@ -21,14 +21,15 @@ public class FinalSnakeChunk extends SnakeChunk {
             ByteBuffer buffer,
             BoundingBox box,
             double dataLength,
-            List<SnakePathPoint> pathData
+            SnakePathPoint[] pathData
     ) {
         super(snake);
 
         assert buffer.position() == BYTE_SIZE;
         assert dataLength > 0;
 
-        this.pathData = pathData;
+        this.pathData = List.of(pathData);
+        this.pathData.forEach(pd -> pd.setFinalSnakeChunk(this));
         chunkByteBuffer = buffer;
         boundingBox = box;
         this.dataLength = dataLength;

--- a/server/src/main/java/game/snake/GrowingSnakeChunk.java
+++ b/server/src/main/java/game/snake/GrowingSnakeChunk.java
@@ -5,12 +5,14 @@ import math.BoundingBox;
 import math.Vector;
 
 import java.nio.ByteBuffer;
+import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 
 public class GrowingSnakeChunk extends SnakeChunk {
     public final char id;
     private final List<SnakePathPoint> pathData = new LinkedList<>();
+    private final List<SnakePathPoint> unmodifiablePathData = Collections.unmodifiableList(pathData);
     private final ChainCodeCoder coder;
     private final Vector end;
     private final float endDirection;
@@ -153,7 +155,7 @@ public class GrowingSnakeChunk extends SnakeChunk {
 
     @Override
     public List<SnakePathPoint> getPathData() {
-        return pathData;
+        return unmodifiablePathData;
     }
 
     @Override

--- a/server/src/main/java/game/snake/GrowingSnakeChunk.java
+++ b/server/src/main/java/game/snake/GrowingSnakeChunk.java
@@ -119,10 +119,8 @@ public class GrowingSnakeChunk extends SnakeChunk {
         }
         BoundingBox box = new BoundingBox(minX, maxX, minY, maxY);
         markAsJunk();
-        final var finalPathData = this.pathData.toArray(new SnakePathPoint[0]);
-        final var fsc = new FinalSnakeChunk(snake, chunkByteBuffer, box, dataLength, List.of(finalPathData));
-        this.pathData.forEach(pd -> pd.setFinalSnakeChunk(fsc));
-        return fsc;
+        final var finalPathData = pathData.toArray(new SnakePathPoint[0]);
+        return new FinalSnakeChunk(snake, chunkByteBuffer, box, dataLength, finalPathData);
     }
 
     private boolean canUpdatePreviousChainCode(int dirDelta, boolean fast) {

--- a/server/src/main/java/game/snake/Snake.java
+++ b/server/src/main/java/game/snake/Snake.java
@@ -177,15 +177,22 @@ public class Snake {
 
     public void shrink(double amount) {
         assert (amount > 0);
+
+        // First take as much as we can from the length buffer.
         final var bufferAmount = Math.min(lengthBuffer, amount);
         lengthBuffer -= bufferAmount;
+
+        // Subtract the remaining amount from the actual snake length.
         final var snakeAmount = amount - bufferAmount;
         final var newLength = Math.max(config.snakes.minLength, length - snakeAmount);
         final var deltaLength = length - newLength;
         length = newLength;
-        final var smallFoodNutritionalValue = config.foodNutritionalValue * Food.Size.SMALL.nutritionalValue;
+
+        // Fill foodTrailBuffer if snake length has changed.
+        final var smallFoodNutritionalValue = config.foodNutritionalValue * Food.Size.SMALL.area / Math.PI;
         foodTrailBuffer += deltaLength * config.foodConversionEfficiency;
 
+        // Spawn food trail items.
         if (foodTrailBuffer >= smallFoodNutritionalValue) {
             foodTrailBuffer -= smallFoodNutritionalValue;
             spawnFoodAtTailPosition();

--- a/server/src/main/java/game/snake/Snake.java
+++ b/server/src/main/java/game/snake/Snake.java
@@ -189,7 +189,7 @@ public class Snake {
         length = newLength;
 
         // Fill foodTrailBuffer if snake length has changed.
-        final var smallFoodNutritionalValue = config.foodNutritionalValue * Food.Size.SMALL.area / Math.PI;
+        final var smallFoodNutritionalValue = Food.Size.SMALL.nutritionalValue(config);
         foodTrailBuffer += deltaLength * config.foodConversionEfficiency;
 
         // Spawn food trail items.

--- a/server/src/main/java/game/snake/Snake.java
+++ b/server/src/main/java/game/snake/Snake.java
@@ -200,10 +200,7 @@ public class Snake {
     }
 
     private void spawnFoodAtTailPosition() {
-        final var tailPosition = getTailPosition();
-        final var worldChunk = world.chunks.findChunk(tailPosition);
-        Food f = new Food(tailPosition, worldChunk, Food.Size.SMALL, skin);
-        worldChunk.addFood(f);
+        Food.spawnAt(getTailPosition(), world, Food.Size.SMALL, skin);
     }
 
     private void handleLengthChange(double snakeSpeed) {

--- a/server/src/main/java/game/snake/SnakeChunk.java
+++ b/server/src/main/java/game/snake/SnakeChunk.java
@@ -91,7 +91,7 @@ public abstract class SnakeChunk implements Collidable {
         // TODO: use binary search instead
 
         double minError = Double.POSITIVE_INFINITY;
-        Vector minPoint = null;
+        Vector bestPoint = null;
 
         for (final var pd : getPathData()) {
             final var offset = pd.getOffsetInChunk();
@@ -104,12 +104,12 @@ public abstract class SnakeChunk implements Collidable {
 
             if (error < minError) {
                 minError = error;
-                minPoint = pd.point;
+                bestPoint = pd.point;
             }
         }
 
-        assert minPoint != null;
-        return minPoint;
+        assert bestPoint != null;
+        return bestPoint;
     }
 
     @Override

--- a/server/src/main/java/game/snake/SnakeChunk.java
+++ b/server/src/main/java/game/snake/SnakeChunk.java
@@ -55,6 +55,10 @@ public abstract class SnakeChunk implements Collidable {
         return clamp(snake.getLength() - getOffset(), 0.0, getDataLength());
     }
 
+    /**
+     * Returns an unmodifiable view of this chunks path data ordered by distance from snake head ascending.
+     * Can contain "junk" data (offset > length) at the end.
+     */
     public abstract List<SnakePathPoint> getPathData();
 
     public final boolean isJunk() {

--- a/server/src/main/java/game/snake/SnakeFactory.java
+++ b/server/src/main/java/game/snake/SnakeFactory.java
@@ -70,26 +70,4 @@ public class SnakeFactory {
         return (byte) ThreadLocalRandom.current().nextInt(Snake.NUMBER_OF_SKINS);
     }
 
-    // TODO: move methods only used by tests to the test source folder
-    public static Snake createTestSnake() {
-        // TODO: use seeded random in tests
-        final double direction = Direction.getRandom(ThreadLocalRandom.current());
-        return createSnake(new Vector(0, 0), direction, new World(), "TestSnake");
-    }
-
-    public static Snake createTestSnake(World world) {
-        // TODO: use seeded random in tests
-        final double direction = Direction.getRandom(ThreadLocalRandom.current());
-        return createSnake(new Vector(0, 0), direction, world, "TestSnake");
-    }
-
-    public static Snake createTestSnake(Vector position, World world) {
-        // TODO: use seeded random in tests
-        final double direction = Direction.getRandom(ThreadLocalRandom.current());
-        return createTestSnake(position, direction, world);
-    }
-
-    public static Snake createTestSnake(Vector position, double direction, World world) {
-        return createSnake(position, direction, world, "TestSnake");
-    }
 }

--- a/server/src/main/java/game/snake/SnakePathPoint.java
+++ b/server/src/main/java/game/snake/SnakePathPoint.java
@@ -2,7 +2,7 @@ package game.snake;
 
 import math.Vector;
 
-public class SnakePathPoint {
+public final class SnakePathPoint {
     public final Vector point;
     private final double localPathLength;
     private SnakeChunk snakeChunk;

--- a/server/src/main/java/game/world/Food.java
+++ b/server/src/main/java/game/world/Food.java
@@ -1,5 +1,6 @@
 package game.world;
 
+import game.GameConfig;
 import math.Vector;
 import util.ByteUtilities;
 
@@ -93,13 +94,15 @@ public final class Food {
         SMALL(0.64, 0), MEDIUM(1.0, 1), LARGE(1.5, 2);
 
         public final double radius;
-        public final double area;
         public final byte byteValue;
 
         Size(double radius, int bv) {
             this.radius = radius;
             this.byteValue = (byte) bv;
-            this.area = Math.PI * radius * radius;
+        }
+
+        public double nutritionalValue(GameConfig config) {
+            return this.radius * this.radius * config.foodNutritionalValue;
         }
     }
 }

--- a/server/src/main/java/game/world/Food.java
+++ b/server/src/main/java/game/world/Food.java
@@ -65,8 +65,12 @@ public class Food {
         }
     }
 
+    /**
+     * Return {@code true} if this food item has a distance less than or equal to
+     * {@code range} from the given point {@code p}.
+     */
     public boolean isWithinRange(Vector p, double range) {
-        // TODO: consider food size
+        range += size.radius;
         return Vector.distance2(position, p) <= range * range;
     }
 

--- a/server/src/main/java/game/world/Food.java
+++ b/server/src/main/java/game/world/Food.java
@@ -9,7 +9,7 @@ import java.util.concurrent.ThreadLocalRandom;
 
 import static util.ByteUtilities.toNormalizedDouble;
 
-public class Food {
+public final class Food {
     public static final int BYTE_SIZE = 3;
 
     public final Vector position;
@@ -87,13 +87,13 @@ public class Food {
         SMALL(0.64, 0), MEDIUM(1.0, 1), LARGE(1.5, 2);
 
         public final double radius;
+        public final double area;
         public final byte byteValue;
-        public final double nutritionalValue;
 
         Size(double radius, int bv) {
             this.radius = radius;
             this.byteValue = (byte) bv;
-            this.nutritionalValue = radius * radius;
+            this.area = Math.PI * radius * radius;
         }
     }
 }

--- a/server/src/main/java/game/world/Food.java
+++ b/server/src/main/java/game/world/Food.java
@@ -5,12 +5,12 @@ import util.ByteUtilities;
 
 import java.nio.ByteBuffer;
 import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
 
 import static util.ByteUtilities.toNormalizedDouble;
 
 public class Food {
     public static final int BYTE_SIZE = 3;
-    private static final Random rand = new Random();
 
     public final Vector position;
     public final Size size;
@@ -38,12 +38,16 @@ public class Food {
     }
 
     public Food(WorldChunk chunk) {
+        Random rand = ThreadLocalRandom.current();
+
         // generate position
         final var bytePosition = new byte[2];
         rand.nextBytes(bytePosition);
+
         // set byte position
         byteX = bytePosition[0];
         byteY = bytePosition[1];
+
         // set global (double) position
         final var x = chunk.box.minX + toNormalizedDouble(bytePosition[0]) * chunk.box.getWidth();
         final var y = chunk.box.minY + toNormalizedDouble(bytePosition[1]) * chunk.box.getHeight();

--- a/server/src/main/java/game/world/Food.java
+++ b/server/src/main/java/game/world/Food.java
@@ -27,35 +27,37 @@ public final class Food {
         this.size = size;
     }
 
-    public Food(Vector position, WorldChunk chunk, Size size, byte color) {
-        this(
+    /**
+     * Spawn a food item at the given position.
+     */
+    public static void spawnAt(Vector position, World world, Size size, byte color) {
+        final var chunk = world.chunks.findChunk(position);
+        final var food = new Food(
                 chunk,
                 ByteUtilities.fromNormalizedDoubleToByte((position.x - chunk.box.minX) / chunk.box.getWidth()),
                 ByteUtilities.fromNormalizedDoubleToByte((position.y - chunk.box.minY) / chunk.box.getHeight()),
                 size,
                 color
         );
+        chunk.addFood(food);
     }
 
-    public Food(WorldChunk chunk) {
+    /**
+     * Spawn food at a random position within the given chunk.
+     */
+    public static void spawnAt(WorldChunk chunk) {
         Random rand = ThreadLocalRandom.current();
 
-        // generate position
+        // Generate random position.
         final var bytePosition = new byte[2];
         rand.nextBytes(bytePosition);
 
-        // set byte position
-        byteX = bytePosition[0];
-        byteY = bytePosition[1];
+        // Pick random color.
+        final var color = (byte) rand.nextInt(64);
 
-        // set global (double) position
-        final var x = chunk.box.minX + toNormalizedDouble(bytePosition[0]) * chunk.box.getWidth();
-        final var y = chunk.box.minY + toNormalizedDouble(bytePosition[1]) * chunk.box.getHeight();
-        position = new Vector(x, y);
-
-        color = (byte) rand.nextInt(64);
-
+        // Pick random size.
         final var sizeProb = rand.nextDouble();
+        final Size size;
         if (0.6 <= sizeProb && sizeProb < 0.9) {
             size = Size.MEDIUM;
         } else if (0.9 <= sizeProb) {
@@ -63,6 +65,10 @@ public final class Food {
         } else {
             size = Size.SMALL;
         }
+
+        // Create food and add to world.
+        final var food = new Food(chunk, bytePosition[0], bytePosition[1], size, color);
+        chunk.addFood(food);
     }
 
     /**

--- a/server/src/main/java/game/world/Food.java
+++ b/server/src/main/java/game/world/Food.java
@@ -66,6 +66,7 @@ public class Food {
     }
 
     public boolean isWithinRange(Vector p, double range) {
+        // TODO: consider food size
         return Vector.distance2(position, p) <= range * range;
     }
 

--- a/server/src/main/java/game/world/Food.java
+++ b/server/src/main/java/game/world/Food.java
@@ -82,14 +82,14 @@ public class Food {
     public enum Size {
         SMALL(0.64, 0), MEDIUM(1.0, 1), LARGE(1.5, 2);
 
-        public final double value;
+        public final double radius;
         public final byte byteValue;
         public final double nutritionalValue;
 
-        Size(double value, int bv) {
-            this.value = value;
+        Size(double radius, int bv) {
+            this.radius = radius;
             this.byteValue = (byte) bv;
-            this.nutritionalValue = value * value;
+            this.nutritionalValue = radius * radius;
         }
     }
 }

--- a/server/src/main/java/game/world/World.java
+++ b/server/src/main/java/game/world/World.java
@@ -83,8 +83,8 @@ public class World {
         // - fine adjust food value per dead snake
         final var foodScattering = 1.0;
         final var caloricValueOfSnake = 0.64 * snake.getLength(); //TODO: adjust
-        final var caloricValueOfFoodSpawn = Food.Size.MEDIUM.radius * Food.Size.MEDIUM.radius * config.foodNutritionalValue;
-        final var numberOfFoodSpawns = (int) (caloricValueOfSnake / caloricValueOfFoodSpawn);
+        final var caloricValueOfFood = Food.Size.MEDIUM.nutritionalValue(config);
+        final var numberOfFoodSpawns = (int) (caloricValueOfSnake / caloricValueOfFood);
         final var lengthUntilFoodSpawn = snake.getLength() / Math.max(1, numberOfFoodSpawns);
 
         for (int i = 0; i < numberOfFoodSpawns; i++) {

--- a/server/src/main/java/game/world/World.java
+++ b/server/src/main/java/game/world/World.java
@@ -96,12 +96,13 @@ public class World {
                 continue;
             }
             spawnPosition.addScaled(new Vector(random.nextDouble(), random.nextDouble()), foodScattering);
+
             if (!box.isWithinSubBox(spawnPosition, 1.0)) {
+                // Ignore out-of-bounds food.
                 continue;
             }
-            final var worldChunk = chunks.findChunk(spawnPosition);
-            final var food = new Food(spawnPosition, worldChunk, Food.Size.MEDIUM, snake.getSkin());
-            worldChunk.addFood(food);
+
+            Food.spawnAt(spawnPosition, this, Food.Size.MEDIUM, snake.getSkin());
         }
     }
 

--- a/server/src/main/java/game/world/World.java
+++ b/server/src/main/java/game/world/World.java
@@ -80,7 +80,7 @@ public class World {
         // - fine adjust food value per dead snake
         final var foodScattering = 1.0;
         final var caloricValueOfSnake = 0.64 * snake.getLength(); //TODO: adjust
-        final var caloricValueOfFoodSpawn = Food.Size.MEDIUM.value * Food.Size.MEDIUM.value * config.foodNutritionalValue;
+        final var caloricValueOfFoodSpawn = Food.Size.MEDIUM.radius * Food.Size.MEDIUM.radius * config.foodNutritionalValue;
         final var numberOfFoodSpawns = (int) (caloricValueOfSnake / caloricValueOfFoodSpawn);
         final var lengthUntilFoodSpawn = snake.getLength() / Math.max(1, numberOfFoodSpawns);
 

--- a/server/src/main/java/game/world/World.java
+++ b/server/src/main/java/game/world/World.java
@@ -22,19 +22,22 @@ public class World {
     @Getter private final HeatMap heatMap;
 
     public World(double chunkSize, int repetitions) {
-        this(new GameConfig(new GameConfig.ChunkInfo(chunkSize, repetitions)));
+        this(new GameConfig(new GameConfig.ChunkInfo(chunkSize, repetitions)), false);
     }
 
     public World() {
         this(32.0, 16);
+        spawnInitialFood();
     }
 
-    public World(GameConfig config) {
+    public World(GameConfig config, boolean spawnFood) {
         this.config = config;
         chunks = WorldChunkFactory.createChunks(this);
         box = new BoundingBox(new Vector(0, 0), config.chunks.size * config.chunks.columns, config.chunks.size * config.chunks.rows);
         heatMap = new HeatMap(config, chunks::stream);
-        spawnInitialFood();
+        if (spawnFood) {
+            spawnInitialFood();
+        }
     }
 
     public Vector findSpawnPosition() {

--- a/server/src/main/java/game/world/World.java
+++ b/server/src/main/java/game/world/World.java
@@ -78,12 +78,10 @@ public class World {
     public void recycleDeadSnake(Snake snake) {
         final var random = getRandom();
 
-        //TODO:
-        // - consider spawning larger food items for larger snakes #120
-        // - fine adjust food value per dead snake
         final var foodScattering = 1.0;
-        final var caloricValueOfSnake = 0.64 * snake.getLength(); //TODO: adjust
-        final var caloricValueOfFood = Food.Size.MEDIUM.nutritionalValue(config);
+        final var caloricValueOfSnake = 0.64 * snake.getLength();
+        final var foodSize = snake.getWidth() > 3.0 ? Food.Size.LARGE : Food.Size.MEDIUM;
+        final var caloricValueOfFood = foodSize.nutritionalValue(config);
         final var numberOfFoodSpawns = (int) (caloricValueOfSnake / caloricValueOfFood);
         final var lengthUntilFoodSpawn = snake.getLength() / Math.max(1, numberOfFoodSpawns);
 
@@ -102,7 +100,7 @@ public class World {
                 continue;
             }
 
-            Food.spawnAt(spawnPosition, this, Food.Size.MEDIUM, snake.getSkin());
+            Food.spawnAt(spawnPosition, this, foodSize, snake.getSkin());
         }
     }
 

--- a/server/src/main/java/game/world/WorldChunk.java
+++ b/server/src/main/java/game/world/WorldChunk.java
@@ -54,7 +54,7 @@ public class WorldChunk {
     }
 
     public void addFood() {
-        addFood(new Food(this));
+        Food.spawnAt(this);
     }
 
     public void addFood(Food food) {

--- a/server/src/main/java/game/world/WorldChunk.java
+++ b/server/src/main/java/game/world/WorldChunk.java
@@ -54,16 +54,11 @@ public class WorldChunk {
     }
 
     public void addFood() {
-        addFood(Collections.singletonList(new Food(this)));
+        addFood(new Food(this));
     }
 
     public void addFood(Food food) {
         foodList.add(food);
-        onFoodChange();
-    }
-
-    public void addFood(Collection<Food> foodItemsToAdd) {
-        foodList.addAll(foodItemsToAdd);
         onFoodChange();
     }
 

--- a/server/src/main/java/server/protocol/GameStatistics.java
+++ b/server/src/main/java/server/protocol/GameStatistics.java
@@ -25,7 +25,7 @@ public class GameStatistics extends ServerToClientJSONMessage {
 
         numBots = game.getNumberOfBots();
         final int numNPCs = numBots + 1; // NPCs: bots and boundary snake
-        numPlayers = game.snakes.size() - numNPCs;
+        numPlayers = game.getSnakes().size() - numNPCs;
     }
 
     private static class LeaderboardEntry {

--- a/server/src/test/java/game/snake/ChainCodeEncodingTest.java
+++ b/server/src/test/java/game/snake/ChainCodeEncodingTest.java
@@ -11,7 +11,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  */
 public class ChainCodeEncodingTest {
 
-    final ChainCodeCoder coder = new ChainCodeCoder(SnakeFactory.createTestSnake());
+    final ChainCodeCoder coder = new ChainCodeCoder(TestSnakeFactory.createSnake());
 
     @Test
     void testAllEncodings() {

--- a/server/src/test/java/game/snake/SnakeChunkTest.java
+++ b/server/src/test/java/game/snake/SnakeChunkTest.java
@@ -81,8 +81,8 @@ public class SnakeChunkTest {
 
     @Test
     void testPathDataLengthRemainsTheSame() {
-        final var world = new World(config);
-        final var snake = SnakeFactory.createTestSnake(new Vector(0, 0), world);
+        final var world = new World(config, false);
+        final var snake = TestSnakeFactory.createSnake(new Vector(0, 0), world);
 
         tickUntilFullLength(snake);
 
@@ -97,7 +97,7 @@ public class SnakeChunkTest {
     @Test
     void testTailChunkDecreasesInLength() {
         final var random = new Random(13374242);
-        final var snake = SnakeFactory.createTestSnake();
+        final var snake = TestSnakeFactory.createSnake();
         snake.grow(64.0);
         tickUntilFullLength(snake);
         tickUntilNewSnakeChunk(snake, random);
@@ -134,7 +134,7 @@ public class SnakeChunkTest {
     @Test
     void testOffsetValues() {
         final var random = new Random(666137);
-        final var snake = SnakeFactory.createTestSnake();
+        final var snake = TestSnakeFactory.createSnake();
         snake.grow(64.0);
         tickUntilFullLength(snake);
         tickUntilNewSnakeChunk(snake, random);
@@ -159,8 +159,8 @@ public class SnakeChunkTest {
     @Test
     void testJunkChunksShouldStayJunk() {
         final var random = new Random(1234);
-        final var world = new World(config);
-        final var snake = SnakeFactory.createTestSnake(new Vector(0, 0), world);
+        final var world = new World(config, false);
+        final var snake = TestSnakeFactory.createSnake(new Vector(0, 0), world);
 
         snake.grow(64.0);
         tickUntilFullLength(snake);
@@ -182,7 +182,7 @@ public class SnakeChunkTest {
     @Test
     void testGetPositionAtMethod() {
         final var random = new Random(314159);
-        final var snake = SnakeFactory.createTestSnake();
+        final var snake = TestSnakeFactory.createSnake();
         snake.grow(64.0);
         tickUntilNewSnakeChunk(snake, random);
         assertTrue(snake.getSnakeChunks().size() > 1);

--- a/server/src/test/java/game/snake/SnakeChunkTest.java
+++ b/server/src/test/java/game/snake/SnakeChunkTest.java
@@ -4,6 +4,8 @@ import game.GameConfig;
 import game.world.World;
 import math.Direction;
 import math.Vector;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -14,6 +16,16 @@ import static org.junit.jupiter.api.Assertions.*;
 
 public class SnakeChunkTest {
     static final GameConfig config = new GameConfig();
+
+    @BeforeAll
+    static void setup() {
+        TestSnakeFactory.setRandom(new Random(747));
+    }
+
+    @AfterAll
+    static void cleanup() {
+        TestSnakeFactory.setRandom(null);
+    }
 
     static double computeSnakeChunkLength(SnakeChunk chunk) {
         final var snakeLength = chunk.getSnake().getLength();

--- a/server/src/test/java/game/snake/SnakeCollisionTest.java
+++ b/server/src/test/java/game/snake/SnakeCollisionTest.java
@@ -1,14 +1,10 @@
 package game.snake;
 
-import game.Game;
 import game.GameConfig;
-import game.world.Collidable;
+import game.world.TestGame;
 import game.world.World;
 import math.Vector;
 import org.junit.jupiter.api.Test;
-
-import java.util.LinkedList;
-import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -24,7 +20,7 @@ public class SnakeCollisionTest {
         final var center = spawnBox.getCenter();
         final var snake1 = SnakeFactory.createTestSnake(new Vector(center.x, center.y + 0.5 * offset), east, world);
         final var snake2 = SnakeFactory.createTestSnake(new Vector(center.x, center.y - 0.5 * offset), east, world);
-        final var testGame = new TestGame(config, world);
+        final var testGame = new TestGame(world);
         testGame.snakes.add(snake1);
         testGame.snakes.add(snake2);
 
@@ -46,7 +42,7 @@ public class SnakeCollisionTest {
         // start with parallel snakes
         final var snake1 = SnakeFactory.createTestSnake(new Vector(center.x, center.y + 0.5 * offset), 0.0, world);
         final var snake2 = SnakeFactory.createTestSnake(new Vector(center.x, center.y - 0.5 * offset), 0.0, world);
-        final var testGame = new TestGame(config, world);
+        final var testGame = new TestGame(world);
         testGame.snakes.add(snake1);
         testGame.snakes.add(snake2);
 
@@ -64,32 +60,10 @@ public class SnakeCollisionTest {
 
         assertEquals(1, testGame.collisions.size(), "Snakes should have collided.");
         final var collision = testGame.collisions.get(0);
-        assertEquals(collision.snake, snake2, "snake2 should be the colliding snake.");
+        assertEquals(collision.snake(), snake2, "snake2 should be the colliding snake.");
 
         testGame.collisions.clear();
         testGame.tickN(1, true);
         assertTrue(testGame.collisions.isEmpty(), "A snake may only collide once!");
-    }
-
-    private static class TestGame extends Game {
-        public final List<CollisionInfo> collisions = new LinkedList<>();
-
-        public TestGame(GameConfig config, World world) {
-            super(config, world);
-            this.collisionManager.onCollisionDo((s, sc) -> collisions.add(new CollisionInfo(s, sc)));
-        }
-
-        public void tickN(int n, boolean stopAfterCollision) {
-            for (int i = 0; i < n; i++) {
-                this.tick();
-
-                if (stopAfterCollision && !collisions.isEmpty()) {
-                    return;
-                }
-            }
-        }
-    }
-
-    private record CollisionInfo(Snake snake, Collidable object) {
     }
 }

--- a/server/src/test/java/game/snake/SnakeCollisionTest.java
+++ b/server/src/test/java/game/snake/SnakeCollisionTest.java
@@ -21,8 +21,8 @@ public class SnakeCollisionTest {
         final var snake1 = TestSnakeFactory.createSnake(new Vector(center.x, center.y + 0.5 * offset), east, world);
         final var snake2 = TestSnakeFactory.createSnake(new Vector(center.x, center.y - 0.5 * offset), east, world);
         final var testGame = new TestGame(world);
-        testGame.snakes.add(snake1);
-        testGame.snakes.add(snake2);
+        testGame.addSnake(snake1);
+        testGame.addSnake(snake2);
 
         testGame.collisionManager.onCollisionDo((s, sc) -> {
             throw new IllegalStateException("These snakes should never collide.");
@@ -43,8 +43,8 @@ public class SnakeCollisionTest {
         final var snake1 = TestSnakeFactory.createSnake(new Vector(center.x, center.y + 0.5 * offset), 0.0, world);
         final var snake2 = TestSnakeFactory.createSnake(new Vector(center.x, center.y - 0.5 * offset), 0.0, world);
         final var testGame = new TestGame(world);
-        testGame.snakes.add(snake1);
-        testGame.snakes.add(snake2);
+        testGame.addSnake(snake1);
+        testGame.addSnake(snake2);
 
         // make snake 1 longer
         snake1.grow(100.0);

--- a/server/src/test/java/game/snake/SnakeCollisionTest.java
+++ b/server/src/test/java/game/snake/SnakeCollisionTest.java
@@ -13,13 +13,13 @@ public class SnakeCollisionTest {
     @Test
     void testParallelSnakesShouldNotCollide() {
         final var config = new GameConfig();
-        final var world = new World(config);
+        final var world = new World(config, false);
         final var spawnBox = world.chunks.findChunk(Vector.ORIGIN).box;
         final var east = 0.0;
         final var offset = Math.max(0.5 * spawnBox.getHeight(), 1.5 * config.snakes.minWidth);
         final var center = spawnBox.getCenter();
-        final var snake1 = SnakeFactory.createTestSnake(new Vector(center.x, center.y + 0.5 * offset), east, world);
-        final var snake2 = SnakeFactory.createTestSnake(new Vector(center.x, center.y - 0.5 * offset), east, world);
+        final var snake1 = TestSnakeFactory.createSnake(new Vector(center.x, center.y + 0.5 * offset), east, world);
+        final var snake2 = TestSnakeFactory.createSnake(new Vector(center.x, center.y - 0.5 * offset), east, world);
         final var testGame = new TestGame(world);
         testGame.snakes.add(snake1);
         testGame.snakes.add(snake2);
@@ -35,13 +35,13 @@ public class SnakeCollisionTest {
     @Test
     void testSimpleCollision() {
         final var config = new GameConfig();
-        final var world = new World(config);
+        final var world = new World(config, false);
         final var spawnBox = world.chunks.findChunk(Vector.ORIGIN).box;
         final var offset = 5 * config.snakes.minWidth;
         final var center = spawnBox.getCenter();
         // start with parallel snakes
-        final var snake1 = SnakeFactory.createTestSnake(new Vector(center.x, center.y + 0.5 * offset), 0.0, world);
-        final var snake2 = SnakeFactory.createTestSnake(new Vector(center.x, center.y - 0.5 * offset), 0.0, world);
+        final var snake1 = TestSnakeFactory.createSnake(new Vector(center.x, center.y + 0.5 * offset), 0.0, world);
+        final var snake2 = TestSnakeFactory.createSnake(new Vector(center.x, center.y - 0.5 * offset), 0.0, world);
         final var testGame = new TestGame(world);
         testGame.snakes.add(snake1);
         testGame.snakes.add(snake2);

--- a/server/src/test/java/game/snake/SnakeEncodingTest.java
+++ b/server/src/test/java/game/snake/SnakeEncodingTest.java
@@ -9,7 +9,7 @@ import java.nio.ByteBuffer;
 import static org.junit.jupiter.api.Assertions.*;
 
 public class SnakeEncodingTest {
-    private static final ChainCodeCoder coder = new ChainCodeCoder(SnakeFactory.createTestSnake());
+    private static final ChainCodeCoder coder = new ChainCodeCoder(TestSnakeFactory.createSnake());
 
     @SuppressWarnings("ConstantConditions")
     @Test
@@ -22,7 +22,7 @@ public class SnakeEncodingTest {
 
     @Test
     void testEarlyChunkBuilding() {
-        Snake snake = SnakeFactory.createTestSnake();
+        Snake snake = TestSnakeFactory.createSnake();
         final char chunkId = 42;
         GrowingSnakeChunk builder = new GrowingSnakeChunk(coder, snake, chunkId);
         assertFalse(builder.isFull());
@@ -34,7 +34,7 @@ public class SnakeEncodingTest {
 
     @Test
     void testSnakeInfoBuffer() {
-        Snake snake = SnakeFactory.createTestSnake();
+        Snake snake = TestSnakeFactory.createSnake();
         var snakeInfo = snake.encodeInfo();
         assertEquals(Snake.INFO_BYTE_SIZE, snakeInfo.capacity());
         var buffer = ByteBuffer.allocate(1 + Snake.INFO_BYTE_SIZE);
@@ -47,7 +47,7 @@ public class SnakeEncodingTest {
     @Test
     void testSnakeChunkBuffer() {
         World world = new World(64.0, 20);
-        Snake snake = SnakeFactory.createTestSnake(new Vector(0, 0), world);
+        Snake snake = TestSnakeFactory.createSnake(new Vector(0, 0), world);
         var n = snake.getSnakeChunks().size();
         var i = 0;
 

--- a/server/src/test/java/game/snake/SnakeEncodingTest.java
+++ b/server/src/test/java/game/snake/SnakeEncodingTest.java
@@ -1,15 +1,28 @@
 package game.snake;
 
 import game.world.World;
-import math.Vector;
+import math.Direction;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import java.nio.ByteBuffer;
+import java.util.Random;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 public class SnakeEncodingTest {
     private static final ChainCodeCoder coder = new ChainCodeCoder(TestSnakeFactory.createSnake());
+
+    @BeforeAll
+    static void setup() {
+        TestSnakeFactory.setRandom(new Random(85694001));
+    }
+
+    @AfterAll
+    static void cleanup() {
+        TestSnakeFactory.setRandom(null);
+    }
 
     @SuppressWarnings("ConstantConditions")
     @Test
@@ -47,7 +60,7 @@ public class SnakeEncodingTest {
     @Test
     void testSnakeChunkBuffer() {
         World world = new World(64.0, 20);
-        Snake snake = TestSnakeFactory.createSnake(new Vector(0, 0), world);
+        Snake snake = TestSnakeFactory.createSnake(world, Direction.DOWN);
         var n = snake.getSnakeChunks().size();
         var i = 0;
 

--- a/server/src/test/java/game/snake/SnakeWidthTest.java
+++ b/server/src/test/java/game/snake/SnakeWidthTest.java
@@ -1,11 +1,26 @@
 package game.snake;
 
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
+import java.util.Random;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class SnakeWidthTest {
+
+    @AfterAll
+    static void cleanup() {
+        TestSnakeFactory.setRandom(null);
+    }
+
+    @BeforeEach
+    void setup() {
+        TestSnakeFactory.setRandom(new Random(9876543));
+    }
+
     @Test
     void testLowerBound() {
         final var snake = TestSnakeFactory.createSnake();

--- a/server/src/test/java/game/snake/SnakeWidthTest.java
+++ b/server/src/test/java/game/snake/SnakeWidthTest.java
@@ -8,7 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class SnakeWidthTest {
     @Test
     void testLowerBound() {
-        final var snake = SnakeFactory.createTestSnake();
+        final var snake = TestSnakeFactory.createSnake();
         final var config = snake.config;
 
         for (int i = 0; i < 256; i++) {
@@ -19,7 +19,7 @@ public class SnakeWidthTest {
 
     @Test
     void testUpperBound() {
-        final var snake = SnakeFactory.createTestSnake();
+        final var snake = TestSnakeFactory.createSnake();
         for (int i = 0; i < 256; i++) {
             snake.tick();
 
@@ -32,7 +32,7 @@ public class SnakeWidthTest {
 
     @Test
     void testBoundedMonotonicity() {
-        final var snake = SnakeFactory.createTestSnake();
+        final var snake = TestSnakeFactory.createSnake();
 
         for (int i = 0; i < 256; i++) {
             snake.tick();
@@ -50,7 +50,7 @@ public class SnakeWidthTest {
 
     @Test
     void testGrowingSnake() {
-        final var snake = SnakeFactory.createTestSnake();
+        final var snake = TestSnakeFactory.createSnake();
         snake.tick();
         var startWidth = snake.getWidth();
 
@@ -76,7 +76,7 @@ public class SnakeWidthTest {
 
     @Test
     void testMinWidth() {
-        final var snake = SnakeFactory.createTestSnake();
+        final var snake = TestSnakeFactory.createSnake();
         final var config = snake.config;
 
         snake.shrink(100.0);

--- a/server/src/test/java/game/snake/TestSnakeFactory.java
+++ b/server/src/test/java/game/snake/TestSnakeFactory.java
@@ -1,30 +1,32 @@
 package game.snake;
 
 import game.world.World;
+import lombok.Setter;
 import math.Direction;
 import math.Vector;
 import org.mockito.Mockito;
 
-import java.util.concurrent.ThreadLocalRandom;
+import java.util.Random;
 
 public class TestSnakeFactory {
     private static char nextSnakeId = (char) 1;
+    @Setter private static Random random;
 
     public static Snake createSnake() {
-        // TODO: use seeded random in tests
-        final double direction = Direction.getRandom(ThreadLocalRandom.current());
-        return SnakeFactory.createSnake(new Vector(0, 0), direction, new World(), "TestSnake");
+        return createSnake(new World());
     }
 
     public static Snake createSnake(World world) {
-        // TODO: use seeded random in tests
-        final double direction = Direction.getRandom(ThreadLocalRandom.current());
+        final double direction = getRandomDirection();
+        return SnakeFactory.createSnake(new Vector(0, 0), direction, world, "TestSnake");
+    }
+
+    public static Snake createSnake(World world, double direction) {
         return SnakeFactory.createSnake(new Vector(0, 0), direction, world, "TestSnake");
     }
 
     public static Snake createSnake(Vector position, World world) {
-        // TODO: use seeded random in tests
-        final double direction = Direction.getRandom(ThreadLocalRandom.current());
+        final double direction = getRandomDirection();
         return createSnake(position, direction, world);
     }
 
@@ -46,5 +48,13 @@ public class TestSnakeFactory {
         world.addSnake(mock);
 
         return mock;
+    }
+
+    private static double getRandomDirection() {
+        if (random == null) {
+            return Direction.RIGHT;
+        }
+
+        return Direction.getRandom(random);
     }
 }

--- a/server/src/test/java/game/snake/TestSnakeFactory.java
+++ b/server/src/test/java/game/snake/TestSnakeFactory.java
@@ -1,0 +1,34 @@
+package game.snake;
+
+import game.world.World;
+import math.Direction;
+import math.Vector;
+import org.mockito.Mockito;
+
+import java.util.concurrent.ThreadLocalRandom;
+
+public class TestSnakeFactory {
+    private static char nextSnakeId = (char) 1;
+
+    public static Snake createSnake() {
+        // TODO: use seeded random in tests
+        final double direction = Direction.getRandom(ThreadLocalRandom.current());
+        return SnakeFactory.createSnake(new Vector(0, 0), direction, new World(), "TestSnake");
+    }
+
+    public static Snake createSnake(World world) {
+        // TODO: use seeded random in tests
+        final double direction = Direction.getRandom(ThreadLocalRandom.current());
+        return SnakeFactory.createSnake(new Vector(0, 0), direction, world, "TestSnake");
+    }
+
+    public static Snake createSnake(Vector position, World world) {
+        // TODO: use seeded random in tests
+        final double direction = Direction.getRandom(ThreadLocalRandom.current());
+        return createSnake(position, direction, world);
+    }
+
+    public static Snake createSnake(Vector position, double direction, World world) {
+        return SnakeFactory.createSnake(position, direction, world, "TestSnake");
+    }
+}

--- a/server/src/test/java/game/snake/TestSnakeFactory.java
+++ b/server/src/test/java/game/snake/TestSnakeFactory.java
@@ -31,4 +31,20 @@ public class TestSnakeFactory {
     public static Snake createSnake(Vector position, double direction, World world) {
         return SnakeFactory.createSnake(position, direction, world, "TestSnake");
     }
+
+    public static Snake createMockedSnake(Vector position, World world) {
+        var id = nextSnakeId++;
+        var snake = new Snake(id, world, "TestSnake", (byte) 0);
+
+        snake.headPosition = position.clone();
+        snake.headDirection = Direction.RIGHT;
+        snake.setTargetDirection(snake.getHeadDirection());
+        snake.beginChunk();
+
+        var mock = Mockito.spy(snake);
+
+        world.addSnake(mock);
+
+        return mock;
+    }
 }

--- a/server/src/test/java/game/world/FoodEatingTest.java
+++ b/server/src/test/java/game/world/FoodEatingTest.java
@@ -40,7 +40,7 @@ public class FoodEatingTest {
         }
 
         // Snake head is now partially in the other chunk and should consume food from it.
-        game.tickN(2, false);
+        game.tickN(1, false);
         assertTrue(neighborChunk.getFoodCount() < foodCount);
     }
 }

--- a/server/src/test/java/game/world/FoodEatingTest.java
+++ b/server/src/test/java/game/world/FoodEatingTest.java
@@ -1,0 +1,46 @@
+package game.world;
+
+import game.snake.TestSnakeFactory;
+import math.Vector;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class FoodEatingTest {
+    @Test
+    void testEatingFoodFromNeighboringChunk() {
+        // Init world.
+        var game = TestGame.createWithSmallWorld();
+        var mainChunk = game.world.chunks.findChunk(Vector.ORIGIN);
+        var neighborChunk = game.world.chunks.findChunk(new Vector(32.0, 0.0));
+
+        // Init snake.
+        var snake = TestSnakeFactory.createMockedSnake(Vector.ORIGIN, game.world);
+        Mockito.when(snake.getWidth()).thenReturn(game.config.snakes.maxWidth);
+        game.addSnake(snake);
+
+        // Add a food item.
+        neighborChunk.addFood(
+                new Food(
+                        new Vector(13.0, 0.0),
+                        neighborChunk,
+                        Food.Size.MEDIUM,
+                        (byte) 0
+                )
+        );
+        assertEquals(0, mainChunk.getFoodCount());
+        var foodCount = neighborChunk.getFoodCount();
+        assertEquals(1, foodCount);
+
+        // Move towards next chunks.
+        while (!neighborChunk.box.isWithinRange(snake.getHeadPosition(), 0.5 * snake.getWidth())) {
+            snake.tick();
+        }
+
+        // Snake head is now partially in the other chunk and should consume food from it.
+        game.tickN(2, false);
+        assertTrue(neighborChunk.getFoodCount() < foodCount);
+    }
+}

--- a/server/src/test/java/game/world/FoodEatingTest.java
+++ b/server/src/test/java/game/world/FoodEatingTest.java
@@ -14,7 +14,8 @@ public class FoodEatingTest {
         // Init world.
         var game = TestGame.createWithSmallWorld();
         var mainChunk = game.world.chunks.findChunk(Vector.ORIGIN);
-        var neighborChunk = game.world.chunks.findChunk(new Vector(32.0, 0.0));
+        var foodPos = new Vector(13.0, 0.0);
+        var neighborChunk = game.world.chunks.findChunk(foodPos);
 
         // Init snake.
         var snake = TestSnakeFactory.createMockedSnake(Vector.ORIGIN, game.world);
@@ -22,14 +23,7 @@ public class FoodEatingTest {
         game.addSnake(snake);
 
         // Add a food item.
-        neighborChunk.addFood(
-                new Food(
-                        new Vector(13.0, 0.0),
-                        neighborChunk,
-                        Food.Size.MEDIUM,
-                        (byte) 0
-                )
-        );
+        Food.spawnAt(foodPos, game.world, Food.Size.MEDIUM, (byte) 0);
         assertEquals(0, mainChunk.getFoodCount());
         var foodCount = neighborChunk.getFoodCount();
         assertEquals(1, foodCount);

--- a/server/src/test/java/game/world/HeatMapTest.java
+++ b/server/src/test/java/game/world/HeatMapTest.java
@@ -1,6 +1,6 @@
 package game.world;
 
-import game.snake.SnakeFactory;
+import game.snake.TestSnakeFactory;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -25,7 +25,7 @@ class HeatMapTest {
     void testNonEmptyWorld() {
         final var world = new World();
         final var heatMap = world.getHeatMap();
-        final var snake = SnakeFactory.createTestSnake(world);
+        final var snake = TestSnakeFactory.createSnake(world);
 
         for (int i = 0; i < 10; i++) {
             snake.tick();

--- a/server/src/test/java/game/world/HeatMapTest.java
+++ b/server/src/test/java/game/world/HeatMapTest.java
@@ -1,6 +1,7 @@
 package game.world;
 
 import game.snake.TestSnakeFactory;
+import math.Direction;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -25,7 +26,7 @@ class HeatMapTest {
     void testNonEmptyWorld() {
         final var world = new World();
         final var heatMap = world.getHeatMap();
-        final var snake = TestSnakeFactory.createSnake(world);
+        final var snake = TestSnakeFactory.createSnake(world, Direction.UP);
 
         for (int i = 0; i < 10; i++) {
             snake.tick();

--- a/server/src/test/java/game/world/TestGame.java
+++ b/server/src/test/java/game/world/TestGame.java
@@ -11,7 +11,7 @@ public class TestGame extends Game {
     public final List<CollisionInfo> collisions = new LinkedList<>();
 
     public TestGame() {
-        super(new GameConfig());
+        this(new World(new GameConfig(), false));
     }
 
     public TestGame(World world) {

--- a/server/src/test/java/game/world/TestGame.java
+++ b/server/src/test/java/game/world/TestGame.java
@@ -2,9 +2,33 @@ package game.world;
 
 import game.Game;
 import game.GameConfig;
+import game.snake.Snake;
+
+import java.util.LinkedList;
+import java.util.List;
 
 public class TestGame extends Game {
+    public final List<CollisionInfo> collisions = new LinkedList<>();
+
     public TestGame() {
         super(new GameConfig());
+    }
+
+    public TestGame(World world) {
+        super(world);
+        this.collisionManager.onCollisionDo((s, sc) -> collisions.add(new CollisionInfo(s, sc)));
+    }
+
+    public void tickN(int n, boolean stopAfterCollision) {
+        for (int i = 0; i < n; i++) {
+            this.tick();
+
+            if (stopAfterCollision && !collisions.isEmpty()) {
+                return;
+            }
+        }
+    }
+
+    public record CollisionInfo(Snake snake, Collidable object) {
     }
 }

--- a/server/src/test/java/game/world/TestGame.java
+++ b/server/src/test/java/game/world/TestGame.java
@@ -19,6 +19,10 @@ public class TestGame extends Game {
         this.collisionManager.onCollisionDo((s, sc) -> collisions.add(new CollisionInfo(s, sc)));
     }
 
+    public static TestGame createWithSmallWorld() {
+        return new TestGame(new World(24.0, 3));
+    }
+
     public void tickN(int n, boolean stopAfterCollision) {
         for (int i = 0; i < n; i++) {
             this.tick();
@@ -27,6 +31,10 @@ public class TestGame extends Game {
                 return;
             }
         }
+    }
+
+    public void addSnake(Snake snake) {
+        this.snakes.add(snake);
     }
 
     public record CollisionInfo(Snake snake, Collidable object) {

--- a/server/src/test/java/game/world/WorldChunkTest.java
+++ b/server/src/test/java/game/world/WorldChunkTest.java
@@ -2,7 +2,9 @@ package game.world;
 
 import game.snake.TestSnakeFactory;
 import math.Vector;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.HashSet;
@@ -14,6 +16,16 @@ import static org.junit.jupiter.api.Assertions.*;
 
 public class WorldChunkTest {
     final World world = new World();
+
+    @AfterAll
+    static void cleanup() {
+        TestSnakeFactory.setRandom(null);
+    }
+
+    @BeforeEach
+    void setup() {
+        TestSnakeFactory.setRandom(new Random(12345678));
+    }
 
     @Test
     void testNumberOfChunks() {

--- a/server/src/test/java/game/world/WorldChunkTest.java
+++ b/server/src/test/java/game/world/WorldChunkTest.java
@@ -1,6 +1,6 @@
 package game.world;
 
-import game.snake.SnakeFactory;
+import game.snake.TestSnakeFactory;
 import math.Vector;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -53,7 +53,7 @@ public class WorldChunkTest {
     @Test
     void testAddASnake() {
         var world = new World();
-        var snake = SnakeFactory.createTestSnake(new Vector(0, 0), world);
+        var snake = TestSnakeFactory.createSnake(new Vector(0, 0), world);
 
         for (int i = 0; i < 512; i++) {
             snake.tick();
@@ -80,7 +80,7 @@ public class WorldChunkTest {
 
     @Test
     void testSnakeHeadChunkIsAlwaysInAChunk() {
-        final var snake = SnakeFactory.createTestSnake(world);
+        final var snake = TestSnakeFactory.createSnake(world);
 
         for (int i = 0; i < 512; i++) {
             snake.tick();
@@ -95,7 +95,7 @@ public class WorldChunkTest {
     @Test
     void testSnakesWithinWorldChunk() {
         var world = new World();
-        var snake = SnakeFactory.createTestSnake(new Vector(0, 0), world);
+        var snake = TestSnakeFactory.createSnake(new Vector(0, 0), world);
 
         for (int i = 0; i < 512; i++) {
             snake.tick();
@@ -113,7 +113,7 @@ public class WorldChunkTest {
     @Test
     void testSnakeGetsRemoved() {
         var world = new World();
-        var snake = SnakeFactory.createTestSnake(new Vector(0, 0), world);
+        var snake = TestSnakeFactory.createSnake(new Vector(0, 0), world);
         snake.tick();
         var worldChunk = world.chunks.stream()
                 .filter(chunk -> chunk.getSnakeChunkCount() > 0)

--- a/server/src/test/java/server/protocol/GameUpdateTest.java
+++ b/server/src/test/java/server/protocol/GameUpdateTest.java
@@ -2,7 +2,7 @@ package server.protocol;
 
 import game.snake.Snake;
 import game.snake.SnakeChunk;
-import game.snake.SnakeFactory;
+import game.snake.TestSnakeFactory;
 import game.world.World;
 import game.world.WorldChunk;
 import math.BoundingBox;
@@ -89,7 +89,7 @@ public class GameUpdateTest {
     @Test
     void testKnowledgeDecay() {
         var client = new TestClient(session);
-        var snake = SnakeFactory.createTestSnake(new Vector(0, 0), world);
+        var snake = TestSnakeFactory.createSnake(new Vector(0, 0), world);
 
         for (int i = 0; i < 10; i++) {
             snake.tick();

--- a/server/src/test/java/server/protocol/GameUpdateTest.java
+++ b/server/src/test/java/server/protocol/GameUpdateTest.java
@@ -6,7 +6,7 @@ import game.snake.TestSnakeFactory;
 import game.world.World;
 import game.world.WorldChunk;
 import math.BoundingBox;
-import math.Vector;
+import math.Direction;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -89,7 +89,7 @@ public class GameUpdateTest {
     @Test
     void testKnowledgeDecay() {
         var client = new TestClient(session);
-        var snake = TestSnakeFactory.createSnake(new Vector(0, 0), world);
+        var snake = TestSnakeFactory.createSnake(world, Direction.LEFT);
 
         for (int i = 0; i < 10; i++) {
             snake.tick();


### PR DESCRIPTION
- Snakes of width larger than 3 (with default config this means length >169) no spawn large food items instead of small ones when they die.
- Food can now be consumed across chunk boundaries.
- Food radius is now accounted for when computing the distance to the snake head.
- Optimized "recycling" of `FinalSnakeChunks` by optimizing for consecutive and successive point queries
- Moved test code in `SnakeFactory.java` to `TestSnakeFactory.java` (which is in the test source folder)
- Improved Food spawning API (should be more readable now).
- Make snake spawning in tests deterministic.

Closes #120