### PR TITLE
Anisotropic filtering

### DIFF
--- a/client/src/app/renderer/modules/SnakeChunkRenderer.ts
+++ b/client/src/app/renderer/modules/SnakeChunkRenderer.ts
@@ -29,7 +29,8 @@ let shader: WebGLShaderProgram;
         1,
         {
             wrap: GL2.REPEAT,
-            minFilter: GL2.LINEAR_MIPMAP_LINEAR
+            minFilter: GL2.LINEAR_MIPMAP_LINEAR,
+            anisotropy: 4
         },
         (gl) => {
             gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, image);

--- a/client/src/app/renderer/webgl/TextureManager.ts
+++ b/client/src/app/renderer/webgl/TextureManager.ts
@@ -32,6 +32,13 @@ export function initTexture(
     if (options.magFilter !== undefined) {
         gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, options.magFilter);
     }
+    if (options.anisotropy !== undefined) {
+        const extension = requireNonNull(
+            gl.getExtension("EXT_texture_filter_anisotropic"),
+            "No anisotropic filtering"
+        );
+        gl.texParameterf(gl.TEXTURE_2D, extension.TEXTURE_MAX_ANISOTROPY_EXT, options.anisotropy);
+    }
 
     if (initializer) {
         initializer(gl, texture, slot);
@@ -44,6 +51,7 @@ type TextureOptions = {
     wrap: number;
     minFilter: number;
     magFilter: number;
+    anisotropy: number;
 };
 
 type TextureInitializer = (gl: WebGL2RenderingContext, texture: WebGLTexture, slot: number) => void;

--- a/client/src/app/renderer/webgl/WebGLContextProvider.ts
+++ b/client/src/app/renderer/webgl/WebGLContextProvider.ts
@@ -40,6 +40,9 @@ export function init(canvas: HTMLCanvasElement): void {
         });
     });
 
+    // Best Mipmap quality (default is DONT_CARE, there is also FASTEST)
+    ctx.hint(ctx.GENERATE_MIPMAP_HINT, ctx.NICEST);
+
     if (__DEBUG__) {
         console.info("Canvas initialized.");
     }

--- a/client/src/app/util/requireNonNull.ts
+++ b/client/src/app/util/requireNonNull.ts
@@ -1,3 +1,11 @@
+/**
+ * Verifies the given value is not null or undefined.
+ * Throws an error otherwise.
+ * The error message will be the second argument or, if omitted, a default one.
+ * @param value Value to check.
+ * @param message Optional error message.
+ * @returns The given value.
+ */
 export default function requireNonNull<T>(value: T | null | undefined, message?: string): T {
     if (value === null || value === undefined) {
         throw new Error(message ?? "Value is " + value);


### PR DESCRIPTION
Adds support for anisotropic filtering for textures. Anisotropic filtering increases image quality when the image gets distorted. For our snakes the texture scale changes from the center to the side resulting in a blurry image. This change improves that.

Also set a WebGL context hint to always generate Mipmaps in the best quality and added a JSDoc comment to the function `requireNonNull`.

References to the documentation can be found in the issue.

Closes #482 